### PR TITLE
Fix file leak in DfWriter

### DIFF
--- a/src/main/java/org/icatproject/ids/thread/DfWriter.java
+++ b/src/main/java/org/icatproject/ids/thread/DfWriter.java
@@ -46,6 +46,7 @@ public class DfWriter implements Runnable {
 				archiveStorageInterface.put(is, dfLocation);
 				Path marker = markerDir.resolve(Long.toString(dfInfo.getDfId()));
 				Files.deleteIfExists(marker);
+				is.close();
 				logger.debug("Removed marker " + marker);
 				logger.debug("Write of " + dfInfo + " completed");
 			} catch (Exception e) {

--- a/src/main/java/org/icatproject/ids/thread/DfWriter.java
+++ b/src/main/java/org/icatproject/ids/thread/DfWriter.java
@@ -39,14 +39,11 @@ public class DfWriter implements Runnable {
 	@Override
 	public void run() {
 		for (DfInfo dfInfo : dfInfos) {
-			try {
-				String dfLocation = dfInfo.getDfLocation();
-				InputStream is = mainStorageInterface.get(dfLocation, dfInfo.getCreateId(),
-						dfInfo.getModId());
+			String dfLocation = dfInfo.getDfLocation();
+			try (InputStream is = mainStorageInterface.get(dfLocation, dfInfo.getCreateId(), dfInfo.getModId())) {
 				archiveStorageInterface.put(is, dfLocation);
 				Path marker = markerDir.resolve(Long.toString(dfInfo.getDfId()));
 				Files.deleteIfExists(marker);
-				is.close();
 				logger.debug("Removed marker " + marker);
 				logger.debug("Write of " + dfInfo + " completed");
 			} catch (Exception e) {


### PR DESCRIPTION
The DfWriter does not close the InputStream it gets from the mainStorageInterface.  As a result, the glassfish process keeps all files copied by the DfWriter into archive storage open.