### PR TITLE
Problematic error handling in DfRestorer and DsRestorer

### DIFF
--- a/src/main/java/org/icatproject/ids/thread/DfRestorer.java
+++ b/src/main/java/org/icatproject/ids/thread/DfRestorer.java
@@ -56,8 +56,10 @@ public class DfRestorer implements Runnable {
 					fsm.removeFromChanging(dfInfo);
 				}
 			} catch (IOException e) {
-				logger.error("Check on existence of {} failed with {} {}", dfInfo.getDfLocation(), e.getClass(),
-						e.getMessage());
+				fsm.recordFailure(dfInfo.getDfId(), "");
+				logger.error("Restore of " + dfInfo + " failed " + e.getClass() + " " + e.getMessage());
+				fsm.removeFromChanging(dfInfo);
+				iter.remove();
 			}
 		}
 

--- a/src/main/java/org/icatproject/ids/thread/DsRestorer.java
+++ b/src/main/java/org/icatproject/ids/thread/DsRestorer.java
@@ -59,13 +59,8 @@ public class DsRestorer implements Runnable {
 			 * generally do anything as pointless restores are normally filtered
 			 * out earlier.
 			 */
-			try {
-				if (mainStorageInterface.exists(dsInfo)) {
-					return;
-				}
-			} catch (IOException e) {
-				logger.error("Check on existence of {} failed with {} {}", dsInfo.getDsLocation(), e.getClass(),
-						e.getMessage());
+			if (mainStorageInterface.exists(dsInfo)) {
+				return;
 			}
 
 			long size = 0;


### PR DESCRIPTION
I just discovered this in DfRestorer and DsRestorer while working on the sources: if mainStorageInterface.exists() throws an IOError, DfRestorer and DsRestorer write an entry to error log, but otherwise ignore the error completely.  In particular they go on, trying to restore the dataset or datafile.  I believe this is certainly not what we want, continuing the restore simply doesn't make sense in this situation.

Note that I found this by reading the sources only, I did not actually observed the problematic behavior.