### PR TITLE
Fix FileCheckerTest: wrong character index reading error log.

### DIFF
--- a/src/test/java/org/icatproject/ids/integration/one/FileCheckerTest.java
+++ b/src/test/java/org/icatproject/ids/integration/one/FileCheckerTest.java
@@ -96,7 +96,7 @@ public class FileCheckerTest extends BaseTest {
 			Thread.sleep(10);
 		}
 		for (String line : Files.readAllLines(errorLog, Charset.defaultCharset())) {
-			lines.add(line.substring(22));
+			lines.add(line.substring(21));
 		}
 		assertEquals(1, lines.size());
 		String msg = new ArrayList<String>(lines).get(0);

--- a/src/test/java/org/icatproject/ids/integration/two/FileCheckerTest.java
+++ b/src/test/java/org/icatproject/ids/integration/two/FileCheckerTest.java
@@ -196,7 +196,7 @@ public class FileCheckerTest extends BaseTest {
 			Thread.sleep(10);
 		}
 		for (String line : Files.readAllLines(errorLog, Charset.defaultCharset())) {
-			lines.add(line.substring(22));
+			lines.add(line.substring(21));
 		}
 		assertEquals(1, lines.size());
 		String msg = new ArrayList<String>(lines).get(0);

--- a/src/test/java/org/icatproject/ids/integration/twodf/FileCheckerTest.java
+++ b/src/test/java/org/icatproject/ids/integration/twodf/FileCheckerTest.java
@@ -90,7 +90,7 @@ public class FileCheckerTest extends BaseTest {
 			Thread.sleep(10);
 		}
 		for (String line : Files.readAllLines(errorLog, Charset.defaultCharset())) {
-			lines.add(line.substring(22));
+			lines.add(line.substring(21));
 		}
 		assertEquals(1, lines.size());
 		String msg = new ArrayList<String>(lines).get(0);


### PR DESCRIPTION
As discussed in the monthly meeting, I was able to run the test suite in the first place.  But I got errors from running the tests:
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
[...]
Running org.icatproject.ids.integration.two.FileCheckerTest
 
Setting up two.properties took 0.021seconds
About to wait
/hmi/payara41/glassfish/domains/domain1/data/ids/archive/284/575 will be truncated to 300
Watching /hmi/payara41/glassfish/domains/domain1/data/ids/errorLog
Watching /hmi/payara41/glassfish/domains/domain1/data/ids/errorLog
Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 39.377 sec <<< FAILURE! - in org.icatproject.ids.integration.two.FileCheckerTest
badZip(org.icatproject.ids.integration.two.FileCheckerTest)  Time elapsed: 24.2 sec  <<< FAILURE!
java.lang.AssertionError: ataset 575 (ds1_1499172150537) datafile uploaded_file_1 java.io.EOFException Unexpected end of ZLIB input stream:Dataset 575
        at org.junit.Assert.fail(Assert.java:91)
        at org.junit.Assert.assertTrue(Assert.java:43)
        at org.icatproject.ids.integration.two.FileCheckerTest.checkHas(FileCheckerTest.java:203)
        at org.icatproject.ids.integration.two.FileCheckerTest.badZip(FileCheckerTest.java:163)

everythingTest(org.icatproject.ids.integration.two.FileCheckerTest)  Time elapsed: 15.073 sec  <<< FAILURE!
java.lang.AssertionError: ataset 587 (ds1_1499172174742) datafile uploaded_file_2 file size wrong:Dataset 587
        at org.junit.Assert.fail(Assert.java:91)
        at org.junit.Assert.assertTrue(Assert.java:43)
        at org.icatproject.ids.integration.two.FileCheckerTest.checkHas(FileCheckerTest.java:203)
        at org.icatproject.ids.integration.two.FileCheckerTest.everythingTest(FileCheckerTest.java:70)

[...]

Running org.icatproject.ids.integration.one.FileCheckerTest
 
Setting up one.properties took 0.024seconds
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5.584 sec <<< FAILURE! - in org.icatproject.ids.integration.one.FileCheckerTest
everythingTest(org.icatproject.ids.integration.one.FileCheckerTest)  Time elapsed: 5.44 sec  <<< FAILURE!
java.lang.AssertionError: atafile 1274 (uploaded_file_2) file size wrong:Datafile 1274
        at org.junit.Assert.fail(Assert.java:91)
        at org.junit.Assert.assertTrue(Assert.java:43)
        at org.icatproject.ids.integration.one.FileCheckerTest.checkHas(FileCheckerTest.java:103)
        at org.icatproject.ids.integration.one.FileCheckerTest.everythingTest(FileCheckerTest.java:61)

[...]
```

I tracked the problem down to an error in the test suite. The tests check the filesCheck.errorLog.  As the error messages reveals, the test fails when it tries to verify that the error message `ataset 575 (ds1_1499172150537) datafile uploaded_file_1 [...]` starts with `Dataset 575`.  Apparently, the first character is missing from the error message.  Indeed, looking at the code, reading the error log …
```java
		for (String line : Files.readAllLines(errorLog, Charset.defaultCharset())) {
			lines.add(line.substring(22));
		}
```
… it chops the first 22 characters of the beginning of each line.  But the lines in the filesCheck.errorLog are of the form `04.07.2017 16:15:36: Datafile 2754 (uploaded_file_2) file size wrong`, e.g. type starts at character 21.