### PR TITLE
Escape single quote characters when building SQL queries as strings

### DIFF
--- a/src/main/java/org/icatproject/ids/IdsBean.java
+++ b/src/main/java/org/icatproject/ids/IdsBean.java
@@ -711,7 +711,7 @@ public class IdsBean {
 				String location = dfInfo.getDfLocation();
 				try {
 					if ((long) reader
-							.search("SELECT COUNT(df) FROM Datafile df WHERE df.location LIKE '" + location + "%'")
+							.search("SELECT COUNT(df) FROM Datafile df WHERE df.location LIKE '" + location.replaceAll("'", "''") + "%'")
 							.get(0) == 0) {
 						if (mainStorage.exists(location)) {
 							logger.debug("Delete physical file " + location + " from main storage");

--- a/src/main/java/org/icatproject/ids/Tidier.java
+++ b/src/main/java/org/icatproject/ids/Tidier.java
@@ -170,35 +170,35 @@ public class Tidier {
 			}
 		}
 
-		private boolean addStringConstraint(StringBuilder sb, String var, String value, boolean andNeeded) {
-			if (value != null) {
-				if (andNeeded) {
-					sb.append(" AND ");
-				} else {
-					sb.append(" ");
-					andNeeded = true;
-				}
-				sb.append(var + " = '" + value + "'");
-			}
-			return andNeeded;
-		}
-
-		private boolean addNumericConstraint(StringBuilder sb, String var, Long value, boolean andNeeded) {
-			if (value != null) {
-				if (andNeeded) {
-					sb.append(" AND ");
-				} else {
-					sb.append(" ");
-					andNeeded = true;
-				}
-				sb.append(var + " = " + value);
-			}
-			return andNeeded;
-		}
-
 	}
 
 	private final static Logger logger = LoggerFactory.getLogger(Tidier.class);;
+
+	static boolean addStringConstraint(StringBuilder sb, String var, String value, boolean andNeeded) {
+		if (value != null) {
+			if (andNeeded) {
+				sb.append(" AND ");
+			} else {
+				sb.append(" ");
+				andNeeded = true;
+			}
+			sb.append(var + " = '" + value.replaceAll("'", "''") + "'");
+		}
+		return andNeeded;
+	}
+
+	static boolean addNumericConstraint(StringBuilder sb, String var, Long value, boolean andNeeded) {
+		if (value != null) {
+			if (andNeeded) {
+				sb.append(" AND ");
+			} else {
+				sb.append(" ");
+				andNeeded = true;
+			}
+			sb.append(var + " = " + value);
+		}
+		return andNeeded;
+	}
 
 	static void cleanPreparedDir(Path preparedDir, int preparedCount) throws IOException {
 

--- a/src/test/java/org/icatproject/ids/TidierTest.java
+++ b/src/test/java/org/icatproject/ids/TidierTest.java
@@ -2,6 +2,7 @@ package org.icatproject.ids;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
@@ -82,4 +83,22 @@ public class TidierTest {
 		assertFalse(Files.exists(pf));
 	}
 
+	@Test
+	public void testAddStringConstraint() throws Exception {
+		StringBuilder sb1 = new StringBuilder();
+		boolean andNeeded = Tidier.addStringConstraint(sb1, "df.location", "/path/to/normal/file", false);
+		assertEquals(" df.location = '/path/to/normal/file'", sb1.toString());
+
+		/* Fix error where a file path contains an apostrophe */
+		StringBuilder sb2 = new StringBuilder();
+		andNeeded = Tidier.addStringConstraint(sb2, "df.location", "/path/to/Person's Files/myscript.py", false);
+		assertEquals(" df.location = '/path/to/Person''s Files/myscript.py'", sb2.toString());
+	}
+
+	@Test
+	public void testAddNumericConstraint() throws Exception {
+		StringBuilder sb3 = new StringBuilder();
+		boolean andNeeded = Tidier.addNumericConstraint(sb3, "df.id", 12345L, false);
+		assertEquals(" df.id = 12345", sb3.toString());
+	}
 }

--- a/src/test/java/org/icatproject/ids/integration/BaseTest.java
+++ b/src/test/java/org/icatproject/ids/integration/BaseTest.java
@@ -293,7 +293,7 @@ public class BaseTest {
 
 			Datafile df4 = new Datafile();
 			df4.setName("df4_" + timestamp);
-			df4.setLocation(ds2Loc + UUID.randomUUID());
+			df4.setLocation(ds2Loc + "Person's file");
 			df4.setDataset(ds2);
 			writeToFile(df4, "df4 test content very compressible very compressible", key);
 


### PR DESCRIPTION
This PR adds a call to the replaceAll string method when the Datafile location is used to build an SQL/JPQL string. The call replaces all single quotes with 2 single quotes which prevents single quotes in file paths from causing problems when the Tidier is run.

I slightly refactored 2 methods in the Tidier to make them easier to test.

This PR fixes #92 in a very simple way and does not address the larger problem of fully and correctly escaping values in JPQL/SQL queries when they are passed between components.