### PR TITLE
Do not check pending deferred operations in the write call

### DIFF
--- a/src/main/java/org/icatproject/ids/IdsBean.java
+++ b/src/main/java/org/icatproject/ids/IdsBean.java
@@ -2104,16 +2104,14 @@ public class IdsBean {
 				boolean maybeOffline = false;
 				if (storageUnit == StorageUnit.DATASET) {
 					for (DsInfo dsInfo : dsInfos.values()) {
-						if (fsm.getDsMaybeOffline().contains(dsInfo) ||
-						    (!dataSelection.getEmptyDatasets().contains(dsInfo.getDsId()) && 
-						     !mainStorage.exists(dsInfo))) {
+						if (!dataSelection.getEmptyDatasets().contains(dsInfo.getDsId()) && 
+						    !mainStorage.exists(dsInfo)) {
 							maybeOffline = true;
 						}
 					}
 				} else if (storageUnit == StorageUnit.DATAFILE) {
 					for (DfInfoImpl dfInfo : dfInfos) {
-						if (fsm.getDfMaybeOffline().contains(dfInfo) || 
-						    !mainStorage.exists(dfInfo.getDfLocation())) {
+						if (!mainStorage.exists(dfInfo.getDfLocation())) {
 							maybeOffline = true;
 						}
 					}


### PR DESCRIPTION
Remove the check for pending deferred operations when checking whether the data selection is online in the write call. This fixes #101.