### PR TITLE
Add a configuration option enableWrite to enable or disable the write call

### DIFF
--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -24,6 +24,7 @@ startArchivingLevel1024bytes = 5000000
 stopArchivingLevel1024bytes =  4000000
 storageUnit = dataset
 tidyBlockSize = 500
+!enableWrite = true
 
 # File checking properties
 filesCheck.parallelCount = 5

--- a/src/main/java/org/icatproject/ids/IdsBean.java
+++ b/src/main/java/org/icatproject/ids/IdsBean.java
@@ -462,6 +462,8 @@ public class IdsBean {
 
 	private DatatypeFactory datatypeFactory;
 
+	private boolean enableWrite;
+
 	@EJB
 	private FiniteStateMachine fsm;
 
@@ -1388,6 +1390,7 @@ public class IdsBean {
 
 				rootUserNames = propertyHandler.getRootUserNames();
 				readOnly = propertyHandler.getReadOnly();
+				enableWrite = propertyHandler.getEnableWrite();
 
 				icat = propertyHandler.getIcatService();
 
@@ -2081,14 +2084,18 @@ public class IdsBean {
 	}
 
 	public void write(String sessionId, String investigationIds, String datasetIds, String datafileIds, String ip)
-			throws BadRequestException, InsufficientPrivilegesException, InternalException, NotFoundException, 
-			       DataNotOnlineException {
+			throws NotImplementedException, BadRequestException, InsufficientPrivilegesException, InternalException, 
+			       NotFoundException, DataNotOnlineException {
 
 		long start = System.currentTimeMillis();
 
 		// Log and validate
 		logger.info("New webservice request: write " + "investigationIds='" + investigationIds + "' " + "datasetIds='"
 				+ datasetIds + "' " + "datafileIds='" + datafileIds + "'");
+
+		if (!enableWrite) {
+			throw new NotImplementedException("This operation has been configured to be unavailable");
+		}
 
 		validateUUID("sessionId", sessionId);
 

--- a/src/main/java/org/icatproject/ids/IdsService.java
+++ b/src/main/java/org/icatproject/ids/IdsService.java
@@ -815,6 +815,7 @@ public class IdsService {
 	 * @param datafileIds
 	 *            If present, a comma separated list of datafile id values.
 	 * 
+	 * @throws NotImplementedException
 	 * @throws BadRequestException
 	 * @throws InsufficientPrivilegesException
 	 * @throws InternalException
@@ -828,8 +829,8 @@ public class IdsService {
 	public void write(@Context HttpServletRequest request, @FormParam("sessionId") String sessionId,
 			@FormParam("investigationIds") String investigationIds, @FormParam("datasetIds") String datasetIds,
 			@FormParam("datafileIds") String datafileIds)
-					throws BadRequestException, InsufficientPrivilegesException, InternalException, NotFoundException, 
-					       DataNotOnlineException {
+					throws NotImplementedException, BadRequestException, InsufficientPrivilegesException, InternalException, 
+					       NotFoundException, DataNotOnlineException {
 		idsBean.write(sessionId, investigationIds, datasetIds, datafileIds, request.getRemoteAddr());
 	}
 }

--- a/src/main/java/org/icatproject/ids/PropertyHandler.java
+++ b/src/main/java/org/icatproject/ids/PropertyHandler.java
@@ -49,6 +49,7 @@ public class PropertyHandler {
 
 	private ArchiveStorageInterface archiveStorage;
 	private Path cacheDir;
+	private boolean enableWrite;
 	private Path filesCheckErrorLog;
 	private int filesCheckGapMillis;
 	private Path filesCheckLastIdFile;
@@ -106,6 +107,11 @@ public class PropertyHandler {
 			}
 
 			readOnly = props.getBoolean("readOnly", false);
+			if (props.has("enableWrite")) {
+				enableWrite = props.getBoolean("enableWrite");
+			} else {
+				enableWrite = ! readOnly;
+			}
 
 			sizeCheckIntervalMillis = props.getPositiveInt("sizeCheckIntervalSeconds") * 1000L;
 
@@ -255,6 +261,10 @@ public class PropertyHandler {
 
 	public Path getCacheDir() {
 		return cacheDir;
+	}
+
+	public boolean getEnableWrite() {
+		return enableWrite;
 	}
 
 	public Path getFilesCheckErrorLog() {

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -206,6 +206,12 @@
 		<dd>The number of datafiles or datasets to get back in one call
 			for archive request when space on main storage is low.</dd>
 
+		<dt>enableWrite</dt>
+		<dd>Optional. If true, the write call will be enabled, if false, it will be
+			disabled. If not set, the readOnly flag will take control and the
+			write call will be disabled if readOnly is true and enabled if
+			not.</dd>
+
 	</dl>
 
 

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -8,6 +8,7 @@
 
 	<h2>Not yet released</h2>
 	<ul>
+		<li>Add an optional configuration option enableWrite.</li>
 		<li>Bump dependency on commons-fileupload to version 1.3.3.</li>
 	</ul>
 


### PR DESCRIPTION
Add a new optional configuration flag `enableWrite` to enable or disable the `write` call.

Fix #105.

This PR does not fix the odd behavior of `archive`, `restore`, and `write` to do nothing and silently succeed with single level storage.  Apparently this has been considered a feature at least once. The removal of that feature should not be hidden in an unrelated bug fix, even if it may be questionable.