### PR TITLE
Throw NotImplementedException for meaningless calls in single level storage

### DIFF
--- a/src/main/java/org/icatproject/ids/IdsBean.java
+++ b/src/main/java/org/icatproject/ids/IdsBean.java
@@ -536,7 +536,8 @@ public class IdsBean {
 	}
 
 	public void archive(String sessionId, String investigationIds, String datasetIds, String datafileIds, String ip)
-			throws BadRequestException, InsufficientPrivilegesException, InternalException, NotFoundException {
+	    throws NotImplementedException, BadRequestException, InsufficientPrivilegesException, InternalException,
+		   NotFoundException {
 
 		long start = System.currentTimeMillis();
 
@@ -561,6 +562,8 @@ public class IdsBean {
 			for (DfInfoImpl dfInfo : dfInfos) {
 				fsm.queue(dfInfo, DeferredOp.ARCHIVE);
 			}
+		} else {
+			throw new NotImplementedException("This operation is unavailable for single level storage");
 		}
 
 		if (logSet.contains(CallType.MIGRATE)) {
@@ -2019,7 +2022,8 @@ public class IdsBean {
 	}
 
 	public void restore(String sessionId, String investigationIds, String datasetIds, String datafileIds, String ip)
-			throws BadRequestException, InsufficientPrivilegesException, InternalException, NotFoundException {
+		throws NotImplementedException, BadRequestException, InsufficientPrivilegesException, InternalException,
+		       NotFoundException {
 
 		long start = System.currentTimeMillis();
 
@@ -2044,6 +2048,8 @@ public class IdsBean {
 			for (DfInfoImpl dfInfo : dfInfos) {
 				fsm.queue(dfInfo, DeferredOp.RESTORE);
 			}
+		} else {
+			throw new NotImplementedException("This operation is unavailable for single level storage");
 		}
 
 		if (logSet.contains(CallType.MIGRATE)) {
@@ -2136,6 +2142,8 @@ public class IdsBean {
 				for (DfInfoImpl dfInfo : dfInfos) {
 					fsm.queue(dfInfo, DeferredOp.WRITE);
 				}
+			} else {
+				throw new NotImplementedException("This operation is unavailable for single level storage");
 			}
 		} catch (AlreadyLockedException e) {
 			logger.debug("Could not acquire lock, write failed");

--- a/src/main/java/org/icatproject/ids/IdsService.java
+++ b/src/main/java/org/icatproject/ids/IdsService.java
@@ -69,6 +69,7 @@ public class IdsService {
 	 * @param datafileIds
 	 *            If present, a comma separated list of datafile id values.
 	 * 
+	 * @throws NotImplementedException
 	 * @throws BadRequestException
 	 * @throws InsufficientPrivilegesException
 	 * @throws InternalException
@@ -82,7 +83,8 @@ public class IdsService {
 	public void archive(@Context HttpServletRequest request, @FormParam("sessionId") String sessionId,
 			@FormParam("investigationIds") String investigationIds, @FormParam("datasetIds") String datasetIds,
 			@FormParam("datafileIds") String datafileIds)
-			throws BadRequestException, InsufficientPrivilegesException, InternalException, NotFoundException {
+			throws NotImplementedException, BadRequestException, InsufficientPrivilegesException, InternalException,
+			       NotFoundException {
 		idsBean.archive(sessionId, investigationIds, datasetIds, datafileIds, request.getRemoteAddr());
 	}
 
@@ -779,6 +781,7 @@ public class IdsService {
 	 * @param datafileIds
 	 *            If present, a comma separated list of datafile id values.
 	 *
+	 * @throws NotImplementedException
 	 * @throws BadRequestException
 	 * @throws InsufficientPrivilegesException
 	 * @throws InternalException
@@ -792,7 +795,8 @@ public class IdsService {
 	public void restore(@Context HttpServletRequest request, @FormParam("sessionId") String sessionId,
 			@FormParam("investigationIds") String investigationIds, @FormParam("datasetIds") String datasetIds,
 			@FormParam("datafileIds") String datafileIds)
-			throws BadRequestException, InsufficientPrivilegesException, InternalException, NotFoundException {
+			throws NotImplementedException, BadRequestException, InsufficientPrivilegesException, InternalException,
+			       NotFoundException {
 		idsBean.restore(sessionId, investigationIds, datasetIds, datafileIds, request.getRemoteAddr());
 	}
 

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -9,6 +9,8 @@
 	<h2>Not yet released</h2>
 	<ul>
 		<li>Add an optional configuration option enableWrite.</li>
+		<li>The API calls archive, restore, and write throw NotImplementedException in the
+			case of single level storage.</li>
 		<li>Bump dependency on commons-fileupload to version 1.3.3.</li>
 	</ul>
 

--- a/src/test/java/org/icatproject/ids/integration/one/MiscTest.java
+++ b/src/test/java/org/icatproject/ids/integration/one/MiscTest.java
@@ -9,6 +9,7 @@ import org.icatproject.ids.integration.BaseTest;
 import org.icatproject.ids.integration.util.Setup;
 import org.icatproject.ids.integration.util.client.DataSelection;
 import org.icatproject.ids.integration.util.client.InsufficientPrivilegesException;
+import org.icatproject.ids.integration.util.client.NotImplementedException;
 import org.icatproject.ids.integration.util.client.TestingClient.Flag;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -57,15 +58,15 @@ public class MiscTest extends BaseTest {
 		}
 	}
 
-	@Test
-	public void restoreHarmlessTest() throws Exception {
-		testingClient.restore(sessionId, new DataSelection().addDataset(datasetIds.get(0)), 204);
+	@Test(expected = NotImplementedException.class)
+	public void restoreNotAvailableTest() throws Exception {
+		testingClient.restore(sessionId, new DataSelection().addDataset(datasetIds.get(0)), 501);
 		waitForIds();
 	}
 
-	@Test
-	public void archiveHarmlessTest() throws Exception {
-		testingClient.archive(sessionId, new DataSelection().addDataset(datasetIds.get(0)), 204);
+	@Test(expected = NotImplementedException.class)
+	public void archiveNotAvailableTest() throws Exception {
+		testingClient.archive(sessionId, new DataSelection().addDataset(datasetIds.get(0)), 501);
 		waitForIds();
 	}
 

--- a/src/test/java/org/icatproject/ids/integration/one/WriteTest.java
+++ b/src/test/java/org/icatproject/ids/integration/one/WriteTest.java
@@ -3,6 +3,7 @@ package org.icatproject.ids.integration.one;
 import org.icatproject.ids.integration.BaseTest;
 import org.icatproject.ids.integration.util.Setup;
 import org.icatproject.ids.integration.util.client.DataSelection;
+import org.icatproject.ids.integration.util.client.NotImplementedException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -14,13 +15,9 @@ public class WriteTest extends BaseTest {
 		icatsetup();
 	}
 
-	/**
-	 * For one level storage, the write call is basically a noop.
-	 * Just verify that it does not throw an error.
-	 */
-	@Test
-	public void writeDataset() throws Exception {
-		testingClient.write(sessionId, new DataSelection().addDataset(datasetIds.get(0)), 204);
+	@Test(expected = NotImplementedException.class)
+	public void writeNotAvailableTest() throws Exception {
+		testingClient.write(sessionId, new DataSelection().addDataset(datasetIds.get(0)), 501);
 	}
 
 }


### PR DESCRIPTION
The calls archive, restore, and write are meaningless for an IDS configured as single level storage.  In the current version, these calls silently do nothing, successfully.  This PR changes this behavior, the calls now throw `NotImplementedException` instead.

This may be considered a somewhat artificial problem.  But it may be confusing if a call returns success while nothing happens.  it is considered a better behavior to send a clear message.