### PR TITLE
Extend getStatus and getSize to accept a preparedID

### DIFF
--- a/src/main/java/org/icatproject/ids/IdsService.java
+++ b/src/main/java/org/icatproject/ids/IdsService.java
@@ -405,6 +405,8 @@ public class IdsService {
 	 * 
 	 * @summary getStatus
 	 * 
+	 * @param preparedId
+	 *            A valid preparedId returned by a call to prepareData
 	 * @param sessionId
 	 *            A sessionId returned by a call to the icat server. If the
 	 *            sessionId is omitted or null the ids reader account will be
@@ -433,11 +435,15 @@ public class IdsService {
 	@GET
 	@Path("getStatus")
 	@Produces(MediaType.TEXT_PLAIN)
-	public String getStatus(@Context HttpServletRequest request, @QueryParam("sessionId") String sessionId,
-			@QueryParam("investigationIds") String investigationIds, @QueryParam("datasetIds") String datasetIds,
-			@QueryParam("datafileIds") String datafileIds)
+	public String getStatus(@Context HttpServletRequest request, @QueryParam("preparedId") String preparedId,
+			@QueryParam("sessionId") String sessionId, @QueryParam("investigationIds") String investigationIds,
+			@QueryParam("datasetIds") String datasetIds, @QueryParam("datafileIds") String datafileIds)
 			throws BadRequestException, NotFoundException, InsufficientPrivilegesException, InternalException {
-		return idsBean.getStatus(sessionId, investigationIds, datasetIds, datafileIds, request.getRemoteAddr());
+		if (preparedId != null) {
+			return idsBean.getStatus(preparedId, request.getRemoteAddr());
+		} else {
+			return idsBean.getStatus(sessionId, investigationIds, datasetIds, datafileIds, request.getRemoteAddr());
+		}
 	}
 
 	@PostConstruct

--- a/src/main/java/org/icatproject/ids/IdsService.java
+++ b/src/main/java/org/icatproject/ids/IdsService.java
@@ -364,6 +364,8 @@ public class IdsService {
 	 * 
 	 * @summary getSize
 	 * 
+	 * @param preparedId
+	 *            A valid preparedId returned by a call to prepareData
 	 * @param sessionId
 	 *            A sessionId returned by a call to the icat server.
 	 * @param investigationIds
@@ -386,11 +388,15 @@ public class IdsService {
 	@GET
 	@Path("getSize")
 	@Produces(MediaType.TEXT_PLAIN)
-	public long getSize(@Context HttpServletRequest request, @QueryParam("sessionId") String sessionId,
-			@QueryParam("investigationIds") String investigationIds, @QueryParam("datasetIds") String datasetIds,
-			@QueryParam("datafileIds") String datafileIds)
+	public long getSize(@Context HttpServletRequest request, @QueryParam("preparedId") String preparedId,
+			@QueryParam("sessionId") String sessionId, @QueryParam("investigationIds") String investigationIds,
+			@QueryParam("datasetIds") String datasetIds, @QueryParam("datafileIds") String datafileIds)
 			throws BadRequestException, NotFoundException, InsufficientPrivilegesException, InternalException {
-		return idsBean.getSize(sessionId, investigationIds, datasetIds, datafileIds, request.getRemoteAddr());
+		if (preparedId != null) {
+			return idsBean.getSize(preparedId, request.getRemoteAddr());
+		} else {
+			return idsBean.getSize(sessionId, investigationIds, datasetIds, datafileIds, request.getRemoteAddr());
+		}
 	}
 
 	/**

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -8,6 +8,7 @@
 
 	<h2>Not yet released</h2>
 	<ul>
+		<li>#104, #110: Extend getStatus() and getSize() to accept a preparedID.</li>
 		<li>Add an optional configuration option enableWrite.</li>
 		<li>Bump dependency on commons-fileupload to version 1.3.3.</li>
 	</ul>

--- a/src/test/java/org/icatproject/ids/integration/one/GetDataExplicitTest.java
+++ b/src/test/java/org/icatproject/ids/integration/one/GetDataExplicitTest.java
@@ -43,6 +43,26 @@ public class GetDataExplicitTest extends BaseTest {
 	}
 
 	@Test
+	public void getSizePreparedId() throws Exception {
+		Datafile df = null;
+		Long size = 0L;
+		try {
+			df = (Datafile) icatWS.get(sessionId, "Datafile INCLUDE 1", datafileIds.get(0));
+			size = df.getFileSize();
+			df.setFileSize(size + 1);
+			icatWS.update(sessionId, df);
+			DataSelection selection = new DataSelection().addDatafiles(datafileIds);
+			String preparedId = testingClient.prepareData(sessionId, selection, Flag.NONE, 200);
+			assertEquals(209L, testingClient.getSize(preparedId, 200));
+		} finally {
+			if (df != null) {
+				df.setFileSize(size);
+				icatWS.update(sessionId, df);
+			}
+		}
+	}
+
+	@Test
 	public void getSizes1() throws Exception {
 		assertEquals(208L, testingClient.getSize(sessionId, new DataSelection().addDatafiles(datafileIds), 200));
 		assertEquals(208L, testingClient.getSize(sessionId, new DataSelection().addDatasets(datasetIds), 200));

--- a/src/test/java/org/icatproject/ids/integration/one/GetStatusExplicitTest.java
+++ b/src/test/java/org/icatproject/ids/integration/one/GetStatusExplicitTest.java
@@ -1,5 +1,7 @@
 package org.icatproject.ids.integration.one;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
 
 import org.icatproject.ids.integration.BaseTest;
@@ -8,6 +10,7 @@ import org.icatproject.ids.integration.util.client.BadRequestException;
 import org.icatproject.ids.integration.util.client.DataSelection;
 import org.icatproject.ids.integration.util.client.InsufficientPrivilegesException;
 import org.icatproject.ids.integration.util.client.NotFoundException;
+import org.icatproject.ids.integration.util.client.TestingClient.Flag;
 import org.icatproject.ids.integration.util.client.TestingClient.Status;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -60,6 +63,16 @@ public class GetStatusExplicitTest extends BaseTest {
 			System.out.println("*" + status + "*");
 		} while (status != Status.ONLINE);
 
+	}
+
+	@Test
+	public void getStatusPreparedIdTest() throws Exception {
+		DataSelection selection = new DataSelection().addDatafile(datafileIds.get(0));
+		String preparedId = testingClient.prepareData(sessionId, selection, Flag.NONE, 200);
+		while (!testingClient.isPrepared(preparedId, 200)) {
+			Thread.sleep(1000);
+		}
+		assertEquals(testingClient.getStatus(preparedId, 200), Status.ONLINE);
 	}
 
 }

--- a/src/test/java/org/icatproject/ids/integration/two/GetDataExplicitTest.java
+++ b/src/test/java/org/icatproject/ids/integration/two/GetDataExplicitTest.java
@@ -61,6 +61,26 @@ public class GetDataExplicitTest extends BaseTest {
 	}
 
 	@Test
+	public void getSizePreparedId() throws Exception {
+		Datafile df = null;
+		Long size = 0L;
+		try {
+			df = (Datafile) icatWS.get(sessionId, "Datafile INCLUDE 1", datafileIds.get(0));
+			size = df.getFileSize();
+			df.setFileSize(size + 1);
+			icatWS.update(sessionId, df);
+			DataSelection selection = new DataSelection().addDatafiles(datafileIds);
+			String preparedId = testingClient.prepareData(sessionId, selection, Flag.NONE, 200);
+			assertEquals(209L, testingClient.getSize(preparedId, 200));
+		} finally {
+			if (df != null) {
+				df.setFileSize(size);
+				icatWS.update(sessionId, df);
+			}
+		}
+	}
+
+	@Test
 	public void correctBehaviourTest() throws Exception {
 
 		try (InputStream z = testingClient.getData(sessionId, new DataSelection().addDatafiles(datafileIds), Flag.NONE,

--- a/src/test/java/org/icatproject/ids/integration/two/GetStatusExplicitTest.java
+++ b/src/test/java/org/icatproject/ids/integration/two/GetStatusExplicitTest.java
@@ -54,6 +54,22 @@ public class GetStatusExplicitTest extends BaseTest {
 	}
 
 	@Test
+	public void getStatusPreparedIdTest() throws Exception {
+		DataSelection selection = new DataSelection().addDatafile(datafileIds.get(0));
+		String preparedId = testingClient.prepareData(sessionId, selection, Flag.NONE, 200);
+		while (!testingClient.isPrepared(preparedId, 200)) {
+			Thread.sleep(1000);
+		}
+		assertEquals(testingClient.getStatus(preparedId, 200), Status.ONLINE);
+		testingClient.archive(sessionId, selection, 204);
+		waitForIds();
+		assertEquals(testingClient.getStatus(preparedId, 200), Status.ARCHIVED);
+		// verify that getStatus() as opposed to isPrepared() does not implicitly trigger a restore.
+		waitForIds();
+		assertEquals(testingClient.getStatus(preparedId, 200), Status.ARCHIVED);
+	}
+
+	@Test
 	public void restoringDatafileRestoresItsDatasetTest() throws Exception {
 		String preparedId = testingClient.prepareData(sessionId,
 				new DataSelection().addDatafile(datafileIds.get(0)), Flag.NONE, 200);

--- a/src/test/java/org/icatproject/ids/integration/twodf/GetDataExplicitTest.java
+++ b/src/test/java/org/icatproject/ids/integration/twodf/GetDataExplicitTest.java
@@ -61,6 +61,26 @@ public class GetDataExplicitTest extends BaseTest {
 	}
 
 	@Test
+	public void getSizePreparedId() throws Exception {
+		Datafile df = null;
+		Long size = 0L;
+		try {
+			df = (Datafile) icatWS.get(sessionId, "Datafile INCLUDE 1", datafileIds.get(0));
+			size = df.getFileSize();
+			df.setFileSize(size + 1);
+			icatWS.update(sessionId, df);
+			DataSelection selection = new DataSelection().addDatafiles(datafileIds);
+			String preparedId = testingClient.prepareData(sessionId, selection, Flag.NONE, 200);
+			assertEquals(209L, testingClient.getSize(preparedId, 200));
+		} finally {
+			if (df != null) {
+				df.setFileSize(size);
+				icatWS.update(sessionId, df);
+			}
+		}
+	}
+
+	@Test
 	public void correctBehaviourTest() throws Exception {
 
 		try (InputStream z = testingClient.getData(sessionId, new DataSelection().addDatafiles(datafileIds), Flag.NONE,

--- a/src/test/java/org/icatproject/ids/integration/twodf/GetStatusExplicitTest.java
+++ b/src/test/java/org/icatproject/ids/integration/twodf/GetStatusExplicitTest.java
@@ -54,6 +54,22 @@ public class GetStatusExplicitTest extends BaseTest {
 	}
 
 	@Test
+	public void getStatusPreparedIdTest() throws Exception {
+		DataSelection selection = new DataSelection().addDatafile(datafileIds.get(0));
+		String preparedId = testingClient.prepareData(sessionId, selection, Flag.NONE, 200);
+		while (!testingClient.isPrepared(preparedId, 200)) {
+			Thread.sleep(1000);
+		}
+		assertEquals(testingClient.getStatus(preparedId, 200), Status.ONLINE);
+		testingClient.archive(sessionId, selection, 204);
+		waitForIds();
+		assertEquals(testingClient.getStatus(preparedId, 200), Status.ARCHIVED);
+		// verify that getStatus() as opposed to isPrepared() does not implicitly trigger a restore.
+		waitForIds();
+		assertEquals(testingClient.getStatus(preparedId, 200), Status.ARCHIVED);
+	}
+
+	@Test
 	public void restoringDatafileDoesNotRestoresItsDatasetTest() throws Exception {
 		String preparedId = testingClient.prepareData(sessionId,
 				new DataSelection().addDatafile(datafileIds.get(0)), Flag.NONE, 200);

--- a/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
+++ b/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
@@ -458,6 +458,25 @@ public class TestingClient {
 		}
 	}
 
+	public long getSize(String preparedId, int sc) throws BadRequestException, NotFoundException,
+			InsufficientPrivilegesException, InternalException, NotImplementedException {
+
+		URIBuilder uriBuilder = getUriBuilder("getSize");
+		uriBuilder.setParameter("preparedId", preparedId);
+		URI uri = getUri(uriBuilder);
+
+		try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+			HttpGet httpGet = new HttpGet(uri);
+			try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+				return Long.parseLong(getString(response, sc));
+			} catch (IOException | InsufficientStorageException | DataNotOnlineException e) {
+				throw new InternalException(e.getClass() + " " + e.getMessage());
+			}
+		} catch (IOException e) {
+			throw new InternalException(e.getClass() + " " + e.getMessage());
+		}
+	}
+
 	public Status getStatus(String sessionId, DataSelection data, Integer sc) throws BadRequestException,
 			NotFoundException, InsufficientPrivilegesException, InternalException, NotImplementedException {
 

--- a/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
+++ b/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
@@ -503,6 +503,27 @@ public class TestingClient {
 
 	}
 
+	public Status getStatus(String preparedId, Integer sc) throws BadRequestException,
+			NotFoundException, InsufficientPrivilegesException, InternalException, NotImplementedException {
+
+		URIBuilder uriBuilder = getUriBuilder("getStatus");
+		uriBuilder.setParameter("preparedId", preparedId);
+		URI uri = getUri(uriBuilder);
+
+		try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+			HttpGet httpGet = new HttpGet(uri);
+
+			try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+				return Status.valueOf(getString(response, sc));
+			} catch (InsufficientStorageException | DataNotOnlineException e) {
+				throw new InternalException(e.getClass() + " " + e.getMessage());
+			}
+		} catch (IOException e) {
+			throw new InternalException(e.getClass() + " " + e.getMessage());
+		}
+
+	}
+
 	private String getString(CloseableHttpResponse response, Integer sc) throws InternalException, BadRequestException,
 			DataNotOnlineException, ParseException, InsufficientPrivilegesException, NotImplementedException,
 			InsufficientStorageException, NotFoundException, IOException {


### PR DESCRIPTION
This is the straightforward implementation of variations of `getStatus()` and `getSize()` that accaept a `preparedID` rather then `investigationIds`, `datasetIds`, and `datafileIds`.  It implements and closes #104.