### PR TITLE
Bump icat.utils to 4.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>icat.utils</artifactId>
-			<version>4.16.0</version>
+			<version>4.16.1-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>icat.utils</artifactId>
-			<version>4.16.1-SNAPSHOT</version>
+			<version>4.16.1</version>
 		</dependency>
 
 		<dependency>

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -9,6 +9,7 @@
 	<h2>devel</h2>
 	<p>Development, no yet released</p>
 	<ul>
+		<li>#116: Bump icat.utils to version 4.16.1.</li>
 		<li>#113: Bump dependency on junit to version 4.13.1.</li>
 	</ul>
 


### PR DESCRIPTION
Bump the dependency on `icat.utils` to 4.16.1 (released on 2021-02-11).  This adds Python 3 compatibility for the `setup` script.