### PR TITLE
119 missing files

### DIFF
--- a/src/main/java/org/icatproject/ids/FiniteStateMachine.java
+++ b/src/main/java/org/icatproject/ids/FiniteStateMachine.java
@@ -624,10 +624,27 @@ public class FiniteStateMachine {
 		}
 	}
 
-	public void checkFailure(Long id) throws InternalException {
+	/**
+	 * Check whether the Dataset/Datafile ID (depending on the StorageUnit set)
+	 * is in the list of IDs that failed to restore. The behaviour then depends 
+	 * on whether the property allowRestoreFailures is set. 
+	 * 
+	 * @param id a Dataset or Datafile ID
+	 * @return true if the ID is found in the list of failures and 
+	 *         allowRestoreFailures is set, false if the ID is not found
+	 * @throws InternalException if the ID is found in the list of failures
+	 *                           and allowRestoreFailures is not set
+	 */
+	public boolean checkFailure(Long id) throws InternalException {
 		if (failures.contains(id)) {
-			throw new InternalException("Restore failed");
-		}
-	}
+			if (propertyHandler.getAllowRestoreFailures()) {
+				return true;
+			} else {
+				throw new InternalException("Restore failed for " +
+						propertyHandler.getStorageUnit().name() + " " + id);
+			}
+	 	}
+	 	return false;
+ 	}
 
 }

--- a/src/main/java/org/icatproject/ids/PropertyHandler.java
+++ b/src/main/java/org/icatproject/ids/PropertyHandler.java
@@ -71,6 +71,7 @@ public class PropertyHandler {
 	private StorageUnit storageUnit;
 	private long delayDatasetWrites;
 	private long delayDatafileOperations;
+	private boolean allowRestoreFailures;
 	private ZipMapperInterface zipMapper;
 	private int tidyBlockSize;
 	private String key;
@@ -244,6 +245,8 @@ public class PropertyHandler {
 				logger.info("'log.list' entry not present so no JMS call logging will be performed");
 			}
 
+			allowRestoreFailures = props.getBoolean("allowRestoreFailures", false);
+
 		} catch (CheckedPropertyException e) {
 			abort(e.getMessage());
 		}
@@ -415,6 +418,10 @@ public class PropertyHandler {
 
 	public org.icatproject.icat.client.ICAT getRestIcat() {
 		return restIcat;
+	}
+
+	public boolean getAllowRestoreFailures() {
+		return allowRestoreFailures;
 	}
 
 }


### PR DESCRIPTION
This is (I believe) the core of the work to fix #119 

I have so far only made the changes I think are required and not tested them, as I would like to check that the way I am doing this is acceptable before I spend a lot of time doing testing. 

If the allowRestoreFailures property is not set the functionality should be unchanged.

If it is set, the changes so far should allow restore requests containing Datasets or Datafiles that do not exist on the archive storage to progress all the way through to passing the isPrepared check or returning ONLINE for getStatus. Only if all the requested items were not found would an Exception be thrown. 

Note that there are no changes yet to allow a "failures" file to be added to the downloaded zip.