### PR TITLE
Use python3 instead of python

### DIFF
--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setup_utils import *
 import os
 

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -9,6 +9,7 @@
 	<h2>1.12.1 (not yet released)</h2>
 	<ul>
 		<li>#122: Bump dependency on logback-classic to version 1.2.0.</li>
+		<li>#128: Use python3 instead of python in the interpreter line of Python scripts</li>
 	</ul>
 
 	<h2>1.12.0</h2>

--- a/src/test/scripts/prepare_test.py
+++ b/src/test/scripts/prepare_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import sys
 import os


### PR DESCRIPTION
Modern distros often don't have a `python` command, so use `python3` explicitly.