### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -32,6 +32,14 @@ jobs:
           python-version: "3.9.7"
           architecture: x64
 
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       # ICAT Ansible clone and install dependencies
       - name: Checkout icat-ansible
         uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,91 @@
+name: CI Build
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_and_tests:
+    runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: 8
+            experimental: false
+          - version: 11
+            experimental: true
+
+    steps:
+      # Setup Java & Python
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.version }}
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9.7"
+          architecture: x64
+
+      # ICAT Ansible clone and install dependencies
+      - name: Checkout icat-ansible
+        uses: actions/checkout@v2
+        with:
+          repository: icatproject-contrib/icat-ansible
+          path: icat-ansible
+          ref: master
+      - name: Install Ansible
+        run: pip install -r icat-ansible/requirements.txt
+
+      # Prep for running the playbook
+      - name: Create Hosts File
+        run: echo -e "[icat_server_dev_hosts]\nlocalhost ansible_connection=local" > icat-ansible/hosts
+      - name: Prepare vault pass
+        run: echo -e "icattravispw" > icat-ansible/vault_pass.txt
+      - name: Move vault to directory it'll get detected by Ansible
+        run: mv icat-ansible/vault.yml icat-ansible/group_vars/all
+      - name: Replace default payara user with Actions user
+        run: |
+          sed -i -e "s/^payara_user: \"glassfish\"/payara_user: \"runner\"/" icat-ansible/group_vars/all/vars.yml
+      - name: Add Ansible roles
+        run: |
+          sed -i "s/- role: icat_lucene/- role: icat_server\\
+          \    - role: ids_storage_file/g" icat-ansible/icat_server_dev_hosts.yml
+
+      # Force hostname to localhost - bug fix for previous ICAT Ansible issues on Actions
+      - name: Change hostname to localhost
+        run: sudo hostname -b localhost
+
+      # Remove existing MySQL installation so it doesn't interfere with GitHub Actions
+      - name: Remove existing mysql
+        run: |
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+          sudo apt-get remove --purge "mysql*"
+          sudo rm -rf /var/lib/mysql* /etc/mysql
+
+      # Create local instance of ICAT
+      - name: Run ICAT Ansible Playbook
+        run: |
+          ansible-playbook icat-ansible/icat_server_dev_hosts.yml -i icat-ansible/hosts --vault-password-file icat-ansible/vault_pass.txt -vv
+
+      - name: Checkout ids-server
+        uses: actions/checkout@v2
+
+      # Payara must be sourced otherwise the Maven build command fails
+      - name: Run Build
+        run: |
+          grep payara ~/.bash_profile > payara_path_command
+          source payara_path_command
+          mvn install -B -DskipTests
+
+      - name: After Failure
+        if: ${{ failure() }}
+        run: |
+          cat /home/runner/logs/ids.log
+          cat /home/runner/logs/icat.log
+          cat /home/runner/payara*/glassfish/domains/domain1/logs/server.log

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -103,6 +103,11 @@ jobs:
       - name: Run Unit Tests
         run: mvn test -B
 
+      # failsafe:integration-test to run the integration tests
+      # failsafe:verify required to check for test failures
+      - name: Run Integration Tests
+        run: mvn failsafe:integration-test failsafe:verify -B
+
       - name: After Failure
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -83,6 +83,9 @@ jobs:
           source payara_path_command
           mvn install -B -DskipTests
 
+      - name: Run Unit Tests
+        run: mvn test -B
+
       - name: After Failure
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -73,6 +73,23 @@ jobs:
         run: |
           ansible-playbook icat-ansible/icat_server_dev_hosts.yml -i icat-ansible/hosts --vault-password-file icat-ansible/vault_pass.txt -vv
 
+      # Prep for the integration tests
+      - name: Checkout ids-storage-test
+        uses: actions/checkout@v2
+        with:
+          repository: icatproject/ids.storage_test
+          path: ids.storage_test
+          ref: master
+      - name: Install ids-storage-test
+        run: |
+          cd ids.storage_test
+          mvn package
+          unzip target/ids.storage_test-*.zip
+          cd ids.storage_test
+          cp properties.example setup.properties
+          sed -i 's+home=/home/fisher/pf/glassfish4+home='"$(realpath /home/runner/payara*)+g" setup.properties
+          ./setup -vv install
+
       - name: Checkout ids-server
         uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-ids.server: Server part of ICAT Data Server (IDS)
--------------------------------------------------
+# ids.server: Server part of ICAT Data Server (IDS)
 
 [![Build Status](https://github.com/icatproject/ids.server/workflows/CI%20Build/badge.svg?branch=master)](https://github.com/icatproject/ids.server/actions?query=workflow%3A%22CI+Build%22)
 

--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,8 @@
 ids.server: Server part of ICAT Data Server (IDS)
 -------------------------------------------------
 
+[![Build Status](https://github.com/icatproject/ids.server/workflows/CI%20Build/badge.svg?branch=master)](https://github.com/icatproject/ids.server/actions?query=workflow%3A%22CI+Build%22)
+
 General installation instructions are at http://www.icatproject.org/installation/component
 
 Specific installation instructions are at https://repo.icatproject.org/site/ids/server/${project.version}/installation.html


### PR DESCRIPTION
Adds CI using GitHub Actions and a status badge to the README. The status badge will start working once this PR gets merged into `master`, but this is the status badge for this branch to prove that it works:

[![Build Status](https://github.com/icatproject/ids.server/workflows/CI%20Build/badge.svg?branch=127-add-ci)](https://github.com/icatproject/ids.server/actions?query=workflow%3A%22CI+Build%22)

- [ ] Should run maven build
- [ ] Should run unit tests
- [ ] Should run integration tests
- [ ] Java 8 CI should fail because of failing integration tests - #129 
- [ ] Java 11 CI should fail (this is experimental)

closes #127 