### PR TITLE
Configure Dependabot version updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates every week
+      interval: "weekly"
+

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.version }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9.7"
           architecture: x64

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,7 +42,7 @@ jobs:
 
       # ICAT Ansible clone and install dependencies
       - name: Checkout icat-ansible
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
@@ -83,7 +83,7 @@ jobs:
 
       # Prep for the integration tests
       - name: Checkout ids-storage-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: icatproject/ids.storage_test
           path: ids.storage_test
@@ -99,7 +99,7 @@ jobs:
           ./setup -vv install
 
       - name: Checkout ids-server
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Payara must be sourced otherwise the Maven build command fails
       - name: Run Build

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Setup Java & Python
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.version }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,7 +33,7 @@ jobs:
           architecture: x64
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,18 +22,18 @@ jobs:
     steps:
       # Setup Java & Python
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@3f07048e3d294f56e9b90ac5ea2c6f74e9ad0f98 # v3.10.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.version }}
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
           python-version: "3.9.7"
           architecture: x64
 
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -42,7 +42,7 @@ jobs:
 
       # ICAT Ansible clone and install dependencies
       - name: Checkout icat-ansible
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
@@ -83,7 +83,7 @@ jobs:
 
       # Prep for the integration tests
       - name: Checkout ids-storage-test
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           repository: icatproject/ids.storage_test
           path: ids.storage_test
@@ -99,7 +99,7 @@ jobs:
           ./setup -vv install
 
       - name: Checkout ids-server
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       # Payara must be sourced otherwise the Maven build command fails
       - name: Run Build


### PR DESCRIPTION
Configures Dependabot to check and open new PRs when new action versions are released. Also addresses the warnings by GitHub Actions in the CI.