### PR TITLE
Drop the test case for file size null in FileCheckerTest

### DIFF
--- a/src/test/java/org/icatproject/ids/integration/one/FileCheckerTest.java
+++ b/src/test/java/org/icatproject/ids/integration/one/FileCheckerTest.java
@@ -56,13 +56,7 @@ public class FileCheckerTest extends BaseTest {
 
 		df.setFileSize(fileSize + 1);
 		icatWS.update(sessionId, df);
-
 		checkHas("Datafile", dfid, "file size wrong");
-
-		df.setFileSize(null);
-		icatWS.update(sessionId, df);
-		Files.deleteIfExists(errorLog);
-		checkHas("Datafile", dfid, "file size null");
 
 		df.setFileSize(fileSize);
 		df.setChecksum("Aardvark");

--- a/src/test/java/org/icatproject/ids/integration/two/FileCheckerTest.java
+++ b/src/test/java/org/icatproject/ids/integration/two/FileCheckerTest.java
@@ -66,13 +66,7 @@ public class FileCheckerTest extends BaseTest {
 
 		df.setFileSize(fileSize + 1);
 		icatWS.update(sessionId, df);
-
 		checkHas("Dataset", datasetIds.get(0), "file size wrong");
-
-		df.setFileSize(null);
-		icatWS.update(sessionId, df);
-		Files.deleteIfExists(errorLog);
-		checkHas("Dataset", datasetIds.get(0), "file size null");
 
 		df.setFileSize(fileSize);
 		df.setChecksum("Aardvark");


### PR DESCRIPTION
Drop the test case for file size null in `org.icatproject.ids.integration.one.FileCheckerTest.everythingTest` and `org.icatproject.ids.integration.two.FileCheckerTest.everythingTest` respectively: this error condition can not be reproduced any more with `icat.server` 5.0 and newer: `Datafile.fileSize` has now a default value of 0, so there is no way any more to set it to `null`. The check for a wrong numeric value in `fileSize` is already covered in the previous test case respectively, so there is no point in keeping that test case at all.

Close #129.
