### PR TITLE
Exclude Java 11 from CI build for the time being

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,15 +9,11 @@ on:
 jobs:
   build_and_tests:
     runs-on: ubuntu-20.04
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - version: 8
-            experimental: false
-          - version: 11
-            experimental: true
 
     steps:
       # Setup Java & Python


### PR DESCRIPTION
The build for Java 8 and for Java 11 cannot succeed both at the same time: as long as we have the `miredot-plugin` at version 1.6.2, the build for Java 11 will  inevitably fail, as soon as we upgrade it, the build for Java 8 will inevitably fail. So it's kind of pointless trying to build for both versions at the same time in the CI build. I'd rather suggest to build only for the Java version that has a chance to succeed, e.g. to exclude the build for Java 11 for the moment and to include the switch from Java 8 to Java 11 in the [payara6](https://github.com/icatproject/ids.server/tree/payara6) branch. This will also get rid of the annoying red x mark for commits that were actually tested successful in the CI, as ac513e0.