### PR TITLE
Upgrade to JakartaEE 10 API for compatibility with Payara 6

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,12 +8,10 @@ on:
 
 jobs:
   build_and_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
-      fail-fast: false
       matrix:
-        include:
-          - version: 11
+        java_version: [11, 17]
 
     steps:
       # Setup Java & Python
@@ -21,12 +19,7 @@ jobs:
         uses: actions/setup-java@3f07048e3d294f56e9b90ac5ea2c6f74e9ad0f98 # v3.10.0
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.version }}
-      - name: Setup Python
-        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
-        with:
-          python-version: "3.9.7"
-          architecture: x64
+          java-version: ${{ matrix.java_version }}
 
       - name: Cache local Maven repository
         uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
@@ -35,6 +28,9 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
+      - name: Run apt-get update
+        run: sudo apt-get update
 
       # ICAT Ansible clone and install dependencies
       - name: Checkout icat-ansible
@@ -71,10 +67,6 @@ jobs:
           sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
           sudo apt-get remove --purge "mysql*"
           sudo rm -rf /var/lib/mysql* /etc/mysql
-
-      # Needed for `maven_artifact` module on Ansible - lxml is in requirements.txt but doesn't seem to work on GitHub Actions
-      - name: Install lxml
-        run: sudo apt-get install python3-lxml
 
       # Create local instance of ICAT
       - name: Run ICAT Ansible Playbook

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: master
+          ref: payara6
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -72,6 +72,10 @@ jobs:
           sudo apt-get remove --purge "mysql*"
           sudo rm -rf /var/lib/mysql* /etc/mysql
 
+      # Needed for `maven_artifact` module on Ansible - lxml is in requirements.txt but doesn't seem to work on GitHub Actions
+      - name: Install lxml
+        run: sudo apt-get install python3-lxml
+
       # Create local instance of ICAT
       - name: Run ICAT Ansible Playbook
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>icat.client</artifactId>
-			<version>6.0.0-SNAPSHOT</version>
+			<version>6.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 		<dependency>
 			<groupId>jakarta.platform</groupId>
 			<artifactId>jakarta.jakartaee-api</artifactId>
-			<version>9.1.0</version>
+			<version>10.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -117,14 +117,14 @@
 		<dependency>
 			<groupId>com.sun.xml.ws</groupId>
 			<artifactId>jaxws-rt</artifactId>
-			<version>3.0.2</version>
+			<version>4.0.0</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>jakarta.json</artifactId>
-			<version>2.0.1</version>
+			<groupId>org.eclipse.parsson</groupId>
+			<artifactId>parsson</artifactId>
+			<version>1.1.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.4.0</version>
 			</plugin>
 
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.icatproject</groupId>
 	<artifactId>ids.server</artifactId>
 	<packaging>war</packaging>
-	<version>1.12.1-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>IDS Server</name>
 
 	<properties>
@@ -120,6 +120,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.sun.xml.ws</groupId>
+			<artifactId>jaxws-rt</artifactId>
+			<version>2.3.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.glassfish</groupId>
 			<artifactId>javax.json</artifactId>
 			<version>1.0.4</version>
@@ -157,7 +164,7 @@
 			<plugin>
 				<groupId>com.qmino</groupId>
 				<artifactId>miredot-plugin</artifactId>
-				<version>1.6.2</version>
+				<version>2.4.1-Java11</version>
 				<executions>
 					<execution>
 						<id>miredot</id>
@@ -253,10 +260,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.10.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<release>11</release>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>icat.client</artifactId>
-			<version>4.10.0</version>
+			<version>6.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -102,9 +102,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax</groupId>
-			<artifactId>javaee-api</artifactId>
-			<version>7.0</version>
+			<groupId>jakarta.platform</groupId>
+			<artifactId>jakarta.jakartaee-api</artifactId>
+			<version>9.1.0</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -114,22 +115,16 @@
 		</dependency>
 
 		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
-			<version>1.3.3</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.sun.xml.ws</groupId>
 			<artifactId>jaxws-rt</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.2</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.glassfish</groupId>
-			<artifactId>javax.json</artifactId>
-			<version>1.0.4</version>
+			<artifactId>jakarta.json</artifactId>
+			<version>2.0.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/org/icatproject/ids/CORSResponseFilter.java
+++ b/src/main/java/org/icatproject/ids/CORSResponseFilter.java
@@ -2,11 +2,11 @@ package org.icatproject.ids;
 
 import java.io.IOException;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class CORSResponseFilter implements ContainerResponseFilter {

--- a/src/main/java/org/icatproject/ids/DataSelection.java
+++ b/src/main/java/org/icatproject/ids/DataSelection.java
@@ -9,9 +9,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonValue;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
 
 import org.icatproject.Datafile;
 import org.icatproject.Dataset;

--- a/src/main/java/org/icatproject/ids/FileChecker.java
+++ b/src/main/java/org/icatproject/ids/FileChecker.java
@@ -18,11 +18,11 @@ import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.ejb.EJB;
-import javax.ejb.Singleton;
-import javax.ejb.Startup;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.ejb.EJB;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
 
 import org.icatproject.Datafile;
 import org.icatproject.Dataset;

--- a/src/main/java/org/icatproject/ids/FiniteStateMachine.java
+++ b/src/main/java/org/icatproject/ids/FiniteStateMachine.java
@@ -20,13 +20,13 @@ import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.ejb.DependsOn;
-import javax.ejb.EJB;
-import javax.ejb.Singleton;
-import javax.json.Json;
-import javax.json.stream.JsonGenerator;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.ejb.DependsOn;
+import jakarta.ejb.EJB;
+import jakarta.ejb.Singleton;
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGenerator;
 
 import org.icatproject.Dataset;
 import org.icatproject.ids.LockManager.Lock;

--- a/src/main/java/org/icatproject/ids/ICATGetter.java
+++ b/src/main/java/org/icatproject/ids/ICATGetter.java
@@ -3,7 +3,7 @@ package org.icatproject.ids;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.xml.ws.WebServiceException;
+import jakarta.xml.ws.WebServiceException;
 
 import org.icatproject.ICAT;
 import org.icatproject.ICATService;

--- a/src/main/java/org/icatproject/ids/IcatReader.java
+++ b/src/main/java/org/icatproject/ids/IcatReader.java
@@ -2,8 +2,8 @@ package org.icatproject.ids;
 
 import java.util.List;
 
-import javax.annotation.PostConstruct;
-import javax.ejb.Singleton;
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Singleton;
 
 import org.icatproject.EntityBaseBean;
 import org.icatproject.ICAT;

--- a/src/main/java/org/icatproject/ids/IdsBean.java
+++ b/src/main/java/org/icatproject/ids/IdsBean.java
@@ -40,17 +40,17 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipOutputStream;
 
-import javax.annotation.PostConstruct;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
-import javax.json.Json;
-import javax.json.JsonNumber;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonValue;
-import javax.json.stream.JsonGenerator;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.EJB;
+import jakarta.ejb.Stateless;
+import jakarta.json.Json;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
 import javax.xml.datatype.DatatypeFactory;
 
 import org.icatproject.Datafile;

--- a/src/main/java/org/icatproject/ids/IdsService.java
+++ b/src/main/java/org/icatproject/ids/IdsService.java
@@ -3,35 +3,33 @@ package org.icatproject.ids;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
-import javax.json.Json;
-import javax.json.stream.JsonGenerator;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.ejb.EJB;
+import jakarta.ejb.Stateless;
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Part;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
-import org.apache.commons.fileupload.FileItemIterator;
-import org.apache.commons.fileupload.FileItemStream;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.fileupload.util.Streams;
 import org.icatproject.ids.exceptions.BadRequestException;
 import org.icatproject.ids.exceptions.DataNotOnlineException;
 import org.icatproject.ids.exceptions.InsufficientPrivilegesException;
@@ -668,11 +666,7 @@ public class IdsService {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response putAsPost(@Context HttpServletRequest request) throws BadRequestException, NotFoundException,
 			InternalException, InsufficientPrivilegesException, NotImplementedException, DataNotOnlineException {
-		if (!ServletFileUpload.isMultipartContent(request)) {
-			throw new BadRequestException("Multipart content expected");
-		}
 		try {
-			ServletFileUpload upload = new ServletFileUpload();
 			String sessionId = null;
 			String name = null;
 			String datafileFormatId = null;
@@ -686,13 +680,11 @@ public class IdsService {
 			boolean padding = false;
 
 			// Parse the request
-			FileItemIterator iter = upload.getItemIterator(request);
-			while (iter.hasNext()) {
-				FileItemStream item = iter.next();
-				String fieldName = item.getFieldName();
-				InputStream stream = item.openStream();
-				if (item.isFormField()) {
-					String value = Streams.asString(stream);
+			for (Part part : request.getParts()) {
+				String fieldName = part.getName();
+				InputStream stream = part.getInputStream();
+				if (part.getSubmittedFileName() == null) {
+					String value = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
 					if (fieldName.equals("sessionId")) {
 						sessionId = value;
 					} else if (fieldName.equals("name")) {
@@ -718,15 +710,17 @@ public class IdsService {
 					}
 				} else {
 					if (name == null) {
-						name = item.getName();
+						name = part.getSubmittedFileName();
 					}
 					result = idsBean.put(stream, sessionId, name, datafileFormatId, datasetId, description, doi,
 							datafileCreateTime, datafileModTime, wrap, padding, request.getRemoteAddr());
 				}
 			}
 			return result;
-		} catch (IOException | FileUploadException e) {
+		} catch (IOException e) {
 			throw new InternalException(e.getClass() + " " + e.getMessage());
+		} catch (ServletException e) {
+			throw new BadRequestException("Multipart content expected");
 		}
 	}
 

--- a/src/main/java/org/icatproject/ids/LockManager.java
+++ b/src/main/java/org/icatproject/ids/LockManager.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.PostConstruct;
-import javax.ejb.Singleton;
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Singleton;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/icatproject/ids/PropertyHandler.java
+++ b/src/main/java/org/icatproject/ids/PropertyHandler.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
-import javax.json.Json;
-import javax.json.JsonReader;
+import jakarta.json.Json;
+import jakarta.json.JsonReader;
 
 import org.icatproject.ICAT;
 import org.icatproject.IcatException_Exception;

--- a/src/main/java/org/icatproject/ids/Tidier.java
+++ b/src/main/java/org/icatproject/ids/Tidier.java
@@ -12,11 +12,11 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.ejb.EJB;
-import javax.ejb.Singleton;
-import javax.ejb.Startup;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.ejb.EJB;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
 
 import org.icatproject.Datafile;
 import org.icatproject.Dataset;

--- a/src/main/java/org/icatproject/ids/Transmitter.java
+++ b/src/main/java/org/icatproject/ids/Transmitter.java
@@ -1,15 +1,15 @@
 package org.icatproject.ids;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.ejb.Singleton;
-import javax.jms.JMSException;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import javax.jms.Topic;
-import javax.jms.TopicConnection;
-import javax.jms.TopicConnectionFactory;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.ejb.Singleton;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import jakarta.jms.Topic;
+import jakarta.jms.TopicConnection;
+import jakarta.jms.TopicConnectionFactory;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 

--- a/src/main/java/org/icatproject/ids/exceptions/IdsExceptionMapper.java
+++ b/src/main/java/org/icatproject/ids/exceptions/IdsExceptionMapper.java
@@ -2,11 +2,11 @@ package org.icatproject.ids.exceptions;
 
 import java.io.ByteArrayOutputStream;
 
-import javax.json.Json;
-import javax.json.stream.JsonGenerator;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 /**
  * Capture any {@link org.icatproject.ids.exceptions.IdsException WebServiceException} thrown from

--- a/src/main/java/org/icatproject/ids/exceptions/NotFoundExceptionMapper.java
+++ b/src/main/java/org/icatproject/ids/exceptions/NotFoundExceptionMapper.java
@@ -2,12 +2,12 @@ package org.icatproject.ids.exceptions;
 
 import java.io.ByteArrayOutputStream;
 
-import javax.json.Json;
-import javax.json.stream.JsonGenerator;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/icatproject/ids/exceptions/RuntimeExceptionMapper.java
+++ b/src/main/java/org/icatproject/ids/exceptions/RuntimeExceptionMapper.java
@@ -4,11 +4,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.net.HttpURLConnection;
 
-import javax.json.Json;
-import javax.json.stream.JsonGenerator;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setup_utils import *
 import os
 

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -55,7 +55,7 @@ if arg == "INSTALL":
 
     try:
         uninstall()
-        actions.createJMSResource("javax.jms.Topic", "jms/IDS/log")
+        actions.createJMSResource("jakarta.jms.Topic", "jms/IDS/log")
 
         ovfiles = [[prop_name, "WEB-INF/classes"]]
         if os.path.exists("logback.xml"): ovfiles.append(["logback.xml", "WEB-INF/classes"])

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -13,7 +13,7 @@
             <param-value>org.icatproject.ids</param-value>
         </init-param>
 
-	<load-on-startup>1</load-on-startup>
+        <load-on-startup>1</load-on-startup>
 
         <multipart-config></multipart-config>
     </servlet>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0">
 
     <servlet>
         <servlet-name>ServletAdaptor</servlet-name>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -10,7 +10,9 @@
             <param-value>org.icatproject.ids</param-value>
         </init-param>
 
-        <load-on-startup>1</load-on-startup>
+	<load-on-startup>1</load-on-startup>
+
+        <multipart-config></multipart-config>
     </servlet>
 
     <servlet-mapping>

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -6,6 +6,12 @@
 
 	<h1>IDS Server Release Notes</h1>
 
+	<h2>2.0.0</h2>
+	<p>Make the transition to Payara 6</p>
+	<ul>
+		<li>#138: Upgrade to Java 11 and JakartaEE 10 API for compatibility with Payara 6</li>
+	</ul>
+
 	<h2>1.12.1</h2>
 	<ul>
 		<li>#122: Bump dependency on logback-classic to version 1.2.0.</li>

--- a/src/test/java/org/icatproject/ids/DataSelectionDevTest.java
+++ b/src/test/java/org/icatproject/ids/DataSelectionDevTest.java
@@ -10,8 +10,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import javax.json.Json;
-import javax.json.JsonReader;
+import jakarta.json.Json;
+import jakarta.json.JsonReader;
 
 import org.icatproject.ICAT;
 import org.icatproject.IcatException_Exception;

--- a/src/test/java/org/icatproject/ids/integration/BaseTest.java
+++ b/src/test/java/org/icatproject/ids/integration/BaseTest.java
@@ -32,8 +32,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
-import javax.json.Json;
-import javax.json.JsonReader;
+import jakarta.json.Json;
+import jakarta.json.JsonReader;
 
 import org.icatproject.Datafile;
 import org.icatproject.DatafileFormat;

--- a/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
+++ b/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
@@ -22,12 +22,12 @@ import java.util.Set;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 
-import javax.json.Json;
-import javax.json.JsonException;
-import javax.json.JsonNumber;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonValue;
+import jakarta.json.Json;
+import jakarta.json.JsonException;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;

--- a/src/test/scripts/prepare_test.py
+++ b/src/test/scripts/prepare_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import sys
 import os


### PR DESCRIPTION
The key changes in this PR are:
 - Imports of JavaEE classes in the `javax` namespace are changed to the `jakarta` namespace.
 - The Java version in increases to Java 11 since this is the minimum supported by JakartaEE.
 - The dependency on commons-fileupload is removed since there is no version compatible with the jakarta namespace. The native multipart handling in the Servlet API is used instead.

The first 2 changes are not backwards-compatible so this is a new major version.
