### PR TITLE
Remove deprecated features and deprecate FileChecker and getLink call

### DIFF
--- a/miredot.htmlintro.html
+++ b/miredot.htmlintro.html
@@ -1,25 +1,26 @@
 <h1>IDS Restful API</h1>
 
 <h2>authorization</h2>
-<p>Most operations require a sessionId from making a login call to
+<p>
+	Most operations require a sessionId from making a login call to
 	ICAT. The sessionId is then used to check that the operation on the
 	data is permitted by following the general rule that if you are allowed
 	that access to the metadata then you are allowed the same access to the
 	data.
+</p>
+
 <h2>Error handling</h2>
-<p>In the case of an error the returned json will be of the form:
+<p>
+	In the case of an error the returned json will be of the form:
 	{"code":"NotFoundException", "message":"One of the data files requested
 	has been deleted"}. Clients should always check the status code and if
-	status/100 is not 2 then an error has occurred.</p>
+	status/100 is not 2 then an error has occurred.
+</p>
 
 <h2>Testing</h2>
 <p>
 	The @GET calls can be tried on a web browser and curl can be used to
 	make any of the calls. For example a url of the form:
-	<kbd> https://example.com:443/ids/getApiVersion</kbd>
-	will return some text such as
-	<samp>1.5.0</samp>
+	<kbd>https://example.com/ids/version</kbd> will return some text such
+	as <samp>{"version":"2.0.0"}</samp>
 </p>
-
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.icatproject</groupId>
 	<artifactId>ids.server</artifactId>
 	<packaging>war</packaging>
-	<version>1.12.2-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>IDS Server</name>
 
 	<properties>

--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -30,14 +30,14 @@ storageUnit = dataset
 tidyBlockSize = 500
 !enableWrite = true
 
-# File checking properties
-filesCheck.parallelCount = 5
-filesCheck.gapSeconds = 5
-filesCheck.lastIdFile = ${HOME}/ids/lastIdFile
-filesCheck.errorLog = ${HOME}/ids/errorLog
+# File checking properties.  Deprecated
+!filesCheck.parallelCount = 5
+!filesCheck.gapSeconds = 5
+!filesCheck.lastIdFile = ${HOME}/ids/lastIdFile
+!filesCheck.errorLog = ${HOME}/ids/errorLog
 
-# Link properties
-linkLifetimeSeconds = 3600
+# Link properties.  Deprecated
+!linkLifetimeSeconds = 3600
 
 # JMS Logging
 log.list = READ WRITE INFO LINK MIGRATE PREPARE

--- a/src/main/java/org/icatproject/ids/FileChecker.java
+++ b/src/main/java/org/icatproject/ids/FileChecker.java
@@ -310,6 +310,7 @@ public class FileChecker {
 		StorageUnit storageUnit = propertyHandler.getStorageUnit();
 		filesCheckParallelCount = propertyHandler.getFilesCheckParallelCount();
 		if (filesCheckParallelCount > 0) {
+			logger.warn("The FileChecker is deprecated and slated for removal in ids.server 3.0");
 			if (storageUnit == null || storageUnit == StorageUnit.DATASET) {
 				filesCheckGapMillis = propertyHandler.getFilesCheckGapMillis();
 				filesCheckLastIdFile = propertyHandler.getFilesCheckLastIdFile();

--- a/src/main/java/org/icatproject/ids/IdsBean.java
+++ b/src/main/java/org/icatproject/ids/IdsBean.java
@@ -1038,6 +1038,8 @@ public class IdsBean {
 
 		if (!linkEnabled) {
 			throw new NotImplementedException("Sorry getLink is not available on this IDS installation");
+		} else {
+			logger.warn("The getLink API call is deprecated and slated for removal in ids.server 3.0");
 		}
 
 		validateUUID("sessionId", sessionId);

--- a/src/main/java/org/icatproject/ids/IdsService.java
+++ b/src/main/java/org/icatproject/ids/IdsService.java
@@ -130,23 +130,6 @@ public class IdsService {
 	/**
 	 * Return the version of the server
 	 * 
-	 * @summary getApiVersion
-	 * 
-	 * @return the version of the ids server
-	 * 
-	 * @statuscode 200 To indicate success
-	 */
-	@GET
-	@Path("getApiVersion")
-	@Produces(MediaType.TEXT_PLAIN)
-	@Deprecated
-	public String getApiVersion() {
-		return Constants.API_VERSION;
-	}
-
-	/**
-	 * Return the version of the server
-	 * 
 	 * @summary Version
 	 * 
 	 * @return json string of the form: <samp>{"version":"4.4.0"}</samp>

--- a/src/main/java/org/icatproject/ids/IdsService.java
+++ b/src/main/java/org/icatproject/ids/IdsService.java
@@ -328,6 +328,7 @@ public class IdsService {
 	@Path("getLink")
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Produces(MediaType.TEXT_PLAIN)
+	@Deprecated
 	public String getLink(@Context HttpServletRequest request, @FormParam("sessionId") String sessionId,
 			@FormParam("datafileId") long datafileId, @FormParam("username") String username)
 			throws BadRequestException, InsufficientPrivilegesException, NotImplementedException, InternalException,

--- a/src/main/java/org/icatproject/ids/PropertyHandler.java
+++ b/src/main/java/org/icatproject/ids/PropertyHandler.java
@@ -181,21 +181,9 @@ public class PropertyHandler {
 					abort("storageUnit value " + props.getString("storageUnit") + " must be taken from " + vs);
 				}
 				if (storageUnit == StorageUnit.DATASET) {
-					if (!props.has("delayDatasetWritesSeconds") && props.has("writeDelaySeconds")) {
-						// compatibility mode
-						logger.warn("writeDelaySeconds is deprecated, please use delayDatasetWritesSeconds instead");
-						delayDatasetWrites = props.getPositiveLong("writeDelaySeconds");
-					} else {
-						delayDatasetWrites = props.getPositiveLong("delayDatasetWritesSeconds");
-					}
+					delayDatasetWrites = props.getPositiveLong("delayDatasetWritesSeconds");
 				} else if (storageUnit == StorageUnit.DATAFILE) {
-					if (!props.has("delayDatafileOperationsSeconds") && props.has("writeDelaySeconds")) {
-						// compatibility mode
-						logger.warn("writeDelaySeconds is deprecated, please use delayDatafileOperationsSeconds instead");
-						delayDatafileOperations = props.getPositiveLong("writeDelaySeconds");
-					} else {
-						delayDatafileOperations = props.getPositiveLong("delayDatafileOperationsSeconds");
-					}
+					delayDatafileOperations = props.getPositiveLong("delayDatafileOperationsSeconds");
 				}
 				tidyBlockSize = props.getPositiveInt("tidyBlockSize");
 			}

--- a/src/main/java/org/icatproject/ids/PropertyHandler.java
+++ b/src/main/java/org/icatproject/ids/PropertyHandler.java
@@ -197,7 +197,11 @@ public class PropertyHandler {
 				abort(cacheDir + " must be an existing directory");
 			}
 
-			filesCheckParallelCount = props.getNonNegativeInt("filesCheck.parallelCount");
+			if (props.has("filesCheck.parallelCount")) {
+				filesCheckParallelCount = props.getNonNegativeInt("filesCheck.parallelCount");
+			} else {
+				filesCheckParallelCount = 0;
+			}
 			if (filesCheckParallelCount > 0) {
 				filesCheckGapMillis = props.getPositiveInt("filesCheck.gapSeconds") * 1000;
 				filesCheckLastIdFile = props.getFile("filesCheck.lastIdFile").toPath();
@@ -210,8 +214,11 @@ public class PropertyHandler {
 				}
 			}
 
-			linkLifetimeMillis = props.getNonNegativeLong("linkLifetimeSeconds") * 1000L;
-
+			if (props.has("linkLifetimeSeconds")) {
+				linkLifetimeMillis = props.getNonNegativeLong("linkLifetimeSeconds") * 1000L;
+			} else {
+				linkLifetimeMillis = 0;
+			}
 			maxIdsInQuery = props.getPositiveInt("maxIdsInQuery");
 
 			/* JMS stuff */

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -34,12 +34,10 @@ if arg == "INSTALL":
         if not idsProperties.get("tidyBlockSize"): abort("tidyBlockSize is not set in ids.properties")
         if not idsProperties.get("storageUnit"): abort("storageUnit is not set in run.properties")
         if idsProperties["storageUnit"].lower == "dataset":
-            if not (idsProperties.get("delayDatasetWritesSeconds") or
-                    idsProperties.get("writeDelaySeconds")):
+            if not (idsProperties.get("delayDatasetWritesSeconds")):
                 abort("delayDatasetWritesSeconds is not set in run.properties")
         if idsProperties["storageUnit"].lower == "datafile":
-            if not (idsProperties.get("delayDatafileOperationsSeconds") or
-                    idsProperties.get("writeDelaySeconds")):
+            if not (idsProperties.get("delayDatafileOperationsSeconds")):
                 abort("delayDatafileOperationsSeconds is not set in run.properties")
 
     if int(idsProperties["filesCheck.parallelCount"]):

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from setup_utils import *
 import os
+import warnings
 
 # ids.server
 
@@ -42,6 +43,7 @@ if arg == "INSTALL":
                 abort("delayDatafileOperationsSeconds is not set in run.properties")
 
     if int(idsProperties["filesCheck.parallelCount"]):
+        warnings.warn("The FileChecker is deprecated and slated for removal in ids.server 3.0")
         if not idsProperties.get("filesCheck.gapSeconds"): abort("filesCheck.gapSeconds is not set in run.properties")
         if not idsProperties.get("filesCheck.lastIdFile"): abort("filesCheck.lastIdFile is not set in run.properties")
         parent = os.path.dirname(os.path.expandvars(idsProperties["filesCheck.lastIdFile"]))
@@ -52,6 +54,9 @@ if arg == "INSTALL":
         if not os.path.exists(parent):
             abort("Please create directory " + parent + " for filesCheck.errorLog specified in run.properties")
         if not idsProperties.get("reader"): abort("reader is not set in run.properties")
+
+    if int(idsProperties["linkLifetimeSeconds"]):
+        warnings.warn("The getLink API call is deprecated and slated for removal in ids.server 3.0")
 
     try:
         uninstall()

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -127,9 +127,13 @@
 		<dd>If true disables write operations (put and delete).</dd>
 
 		<dt>linkLifetimeSeconds</dt>
-		<dd>The length of time in seconds to keep the links established
-			by the getLink call. If this is set to zero then the getLink call
-			will return a NotImplementedException.</dd>
+		<dd>Optional, default zero. The length of time in seconds to keep the links
+			established by the getLink call. If this is set to zero then the getLink
+			call is disabled.
+			<p><strong>Deprecated:</strong> the getLink call is deprecated
+				and slated for removal along with this property in
+				ids.server 3.0.</p>
+		</dd>
 
 		<dt>reader</dt>
 		<dd>
@@ -230,10 +234,12 @@
 		computed and stored in ICAT. File checking, if enabled, cycles through
 		all the stored data making sure that they can be read and that files
 		have the expected size and checksum.</p>
+	<p><strong>Deprecated:</strong> the FileChecker is deprecated and slated for removal
+		along with the properties in this section in ids.server 3.0.</p>
 	<dl>
 		<dt>filesCheck.parallelCount</dt>
 		<dd>
-			This must always be set, and if non zero then the readability of the
+			Optional, default zero. If non zero then the readability of the
 			data will be checked. The behaviour is dependent upon whether or not
 			archive storage has a been requested. In the case of single level
 			storage this is done in groups of files where the group size is
@@ -247,6 +253,8 @@
 			<p>If the archive storage has a long latency then it is useful to
 				have a "large" value, however a thread is started for each stored
 				file so the value of this parameter should not be too large.</p>
+			<p>If this is set to zero then the FileChecker is disabled and all other
+				properties in this section will be ignored.</p>
 		</dd>
 		<dt>filesCheck.gapSeconds</dt>
 		<dd>the number of seconds to wait before launching a check of the

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -8,7 +8,9 @@
 
 	<h2>2.0.0</h2>
 	<ul>
-		<li>#139: Deprecate FileChecker and getLink call</li>
+		<li>#139: Remove getApiVersion call, deprecated in 1.8.0.
+			Remove runtime property	writeDelaySeconds, deprecated in 1.10.0.
+			Deprecate FileChecker and getLink call</li>
 	</ul>
 
 	<h2>1.12.1</h2>

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -6,6 +6,11 @@
 
 	<h1>IDS Server Release Notes</h1>
 
+	<h2>2.0.0</h2>
+	<ul>
+		<li>#139: Deprecate FileChecker and getLink call</li>
+	</ul>
+
 	<h2>1.12.1</h2>
 	<ul>
 		<li>#122: Bump dependency on logback-classic to version 1.2.0.</li>

--- a/src/test/java/org/icatproject/ids/integration/BaseTest.java
+++ b/src/test/java/org/icatproject/ids/integration/BaseTest.java
@@ -494,10 +494,6 @@ public class BaseTest {
 		System.out.println(testingClient.getIcatUrl(200));
 	}
 
-	protected void apiVersionTest() throws Exception {
-		assertTrue(testingClient.getApiVersion(200).startsWith("1.8."));
-	}
-
 	protected void raceTest() throws Exception {
 		logTime("Starting");
 

--- a/src/test/java/org/icatproject/ids/integration/one/BaseTests.java
+++ b/src/test/java/org/icatproject/ids/integration/one/BaseTests.java
@@ -19,11 +19,6 @@ public class BaseTests extends BaseTest {
 	}
 
 	@Test
-	public void apiVersionTest() throws Exception {
-		super.apiVersionTest();
-	}
-
-	@Test
 	public void getDatafileIdsTest() throws Exception {
 		super.getDatafileIdsTest();
 	}

--- a/src/test/java/org/icatproject/ids/integration/two/BaseTests.java
+++ b/src/test/java/org/icatproject/ids/integration/two/BaseTests.java
@@ -26,11 +26,6 @@ public class BaseTests extends BaseTest {
 	}
 
 	@Test
-	public void apiVersionTest() throws Exception {
-		super.apiVersionTest();
-	}
-
-	@Test
 	public void getDatafileIdsTest() throws Exception {
 		super.getDatafileIdsTest();
 	}

--- a/src/test/java/org/icatproject/ids/integration/twodf/BaseTests.java
+++ b/src/test/java/org/icatproject/ids/integration/twodf/BaseTests.java
@@ -26,11 +26,6 @@ public class BaseTests extends BaseTest {
 	}
 
 	@Test
-	public void apiVersionTest() throws Exception {
-		super.apiVersionTest();
-	}
-
-	@Test
 	public void getDatafileIdsTest() throws Exception {
 		super.getDatafileIdsTest();
 	}

--- a/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
+++ b/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
@@ -248,21 +248,6 @@ public class TestingClient {
 		}
 	}
 
-	public String getApiVersion(int sc) throws InternalException, ParseException, NotImplementedException {
-		URI uri = getUri(getUriBuilder("getApiVersion"));
-		try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-			HttpGet httpGet = new HttpGet(uri);
-			try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
-				return getString(response, sc);
-			} catch (IOException | InsufficientStorageException | DataNotOnlineException | BadRequestException
-					| InsufficientPrivilegesException | NotFoundException e) {
-				throw new InternalException(e.getClass() + " " + e.getMessage());
-			}
-		} catch (IOException e) {
-			throw new InternalException(e.getClass() + " " + e.getMessage());
-		}
-	}
-
 	public URL getIcatUrl(int sc) throws InternalException, ParseException, NotImplementedException {
 		URI uri = getUri(getUriBuilder("getIcatUrl"));
 		try (CloseableHttpClient httpclient = HttpClients.createDefault()) {


### PR DESCRIPTION
Remove deprecated features:

- Remove `getApiVersion` call, deprecated in 1.8.0,
- Remove runtime property `writeDelaySeconds`, deprecated in 1.10.0.

Deprecate the `FileChecker` and the `getLink` API call. Both features are slated for definitive removal in version 3.0.

- Issue a warning in the `setup` script if either is enabled in `run.properties`,
- Log a warning during initialization if the `FileChecker` is enabled,
- Log a warning when the `getLink` call is invoked, if it is enabled.