### PR TITLE
Use master from icatproject-contrib/icat-ansible rather than payara6

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: payara6
+          ref: master
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 


### PR DESCRIPTION
Switch back using the master branch from icatproject-contrib/icat-ansible after icatproject-contrib/icat-ansible#84 has been merged.