### PR TITLE
Include Content-Length response header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/icatproject/ids/DataSelection.java
+++ b/src/main/java/org/icatproject/ids/DataSelection.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
 
 import jakarta.json.Json;
@@ -53,6 +54,7 @@ public class DataSelection {
     private Set<Long> emptyDatasets;
     private boolean dsWanted;
     private boolean dfWanted;
+    private long length;
 
 
     public enum Returns {
@@ -135,6 +137,7 @@ public class DataSelection {
                     dsInfos.put(dsid, new DsInfoImpl(ds));
                     if (dfWanted) {
                         Datafile df = (Datafile) icat.get(userSessionId, "Datafile", dfid);
+                        length += df.getFileSize();
                         String location = IdsBean.getLocation(dfid, df.getLocation());
                         dfInfos.add(
                                 new DfInfoImpl(dfid, df.getName(), location, df.getCreateId(), df.getModId(), dsid));
@@ -315,4 +318,10 @@ public class DataSelection {
         return emptyDatasets;
     }
 
+    public OptionalLong getFileLength() {
+        if (!dfWanted || mustZip()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(length);
+    }
 }

--- a/src/main/java/org/icatproject/ids/IdsBean.java
+++ b/src/main/java/org/icatproject/ids/IdsBean.java
@@ -20,6 +20,7 @@ import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -50,6 +51,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonGenerator;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
@@ -859,6 +861,7 @@ public class IdsBean {
         // Do it
         Map<Long, DsInfo> dsInfos = dataSelection.getDsInfo();
         Set<DfInfoImpl> dfInfos = dataSelection.getDfInfo();
+        var length = zip ? OptionalLong.empty() : dataSelection.getFileLength();
 
         Lock lock = null;
         try {
@@ -909,11 +912,14 @@ public class IdsBean {
                 }
             }
 
-            return Response.status(offset == 0 ? HttpURLConnection.HTTP_OK : HttpURLConnection.HTTP_PARTIAL)
+            var response = Response.status(offset == 0 ? HttpURLConnection.HTTP_OK : HttpURLConnection.HTTP_PARTIAL)
                     .entity(new SO(dataSelection.getDsInfo(), dataSelection.getDfInfo(), offset, finalZip, compress, lock,
                             transferId, ip, start))
-                    .header("Content-Disposition", "attachment; filename=\"" + name + "\"").header("Accept-Ranges", "bytes")
-                    .build();
+                    .header("Content-Disposition", "attachment; filename=\"" + name + "\"").header("Accept-Ranges", "bytes");
+            length.stream()
+                    .map(l -> Math.max(0L, l - offset))
+                    .forEach(l -> response.header(CONTENT_LENGTH, l));
+            return response.build();
         } catch (AlreadyLockedException e) {
             logger.debug("Could not acquire lock, getData failed");
             throw new DataNotOnlineException("Data is busy");

--- a/src/test/java/org/icatproject/ids/integration/BaseTest.java
+++ b/src/test/java/org/icatproject/ids/integration/BaseTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.UUID;
 import java.util.zip.CRC32;
@@ -367,6 +369,16 @@ public class BaseTest {
             }
         }
         assertTrue(found);
+    }
+
+    protected long fileLength(long id) {
+        for (Entry<String, Long> e : ids.entrySet()) {
+            if (id == e.getValue()) {
+                var fileContents = contents.get(e.getKey());
+                return fileContents.getBytes(StandardCharsets.UTF_8).length;
+            }
+        }
+        throw new NoSuchElementException("No file with id " + id);
     }
 
     protected void writeToFile(Datafile df, String content, String key)

--- a/src/test/java/org/icatproject/ids/integration/one/GetDataExplicitTest.java
+++ b/src/test/java/org/icatproject/ids/integration/one/GetDataExplicitTest.java
@@ -2,6 +2,8 @@ package org.icatproject.ids.integration.one;
 
 import java.io.InputStream;
 import java.util.Arrays;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
@@ -99,12 +101,23 @@ public class GetDataExplicitTest extends BaseTest {
     @Test
     public void correctBehaviourTestNone() throws Exception {
         try (InputStream stream = testingClient.getData(sessionId, new DataSelection().addDatafiles(datafileIds),
-                Flag.NONE, 0, 200)) {
+                Flag.NONE, 0, 200, r -> {
+                    assertThat(r.getFirstHeader("Content-Length"), is(nullValue()));
+                    assertThat(r.getFirstHeader("Transfer-Encoding").getValue(),
+                            is(equalToIgnoringCase("chunked")));
+                })) {
             checkZipStream(stream, datafileIds, 57L, 0);
         }
 
-        try (InputStream stream = testingClient.getData(sessionId, new DataSelection().addDatafile(datafileIds.get(0)),
-                Flag.NONE, 0, 200)) {
+        var datafileId = datafileIds.get(0);
+        var fileLength = fileLength(datafileId);
+        try (InputStream stream = testingClient.getData(sessionId, new DataSelection().addDatafile(datafileId),
+                Flag.NONE, 0, 200, r -> {
+                    assertThat(r.getFirstHeader("Content-Length"), is(not(nullValue())));
+                    var contentLength = r.getFirstHeader("Content-Length").getValue();
+                    assertThat(Long.valueOf(contentLength), is(equalTo(fileLength)));
+                    assertThat(r.getFirstHeader("Transfer-Encoding"), is(nullValue()));
+                })) {
             checkStream(stream, datafileIds.get(0));
         }
     }
@@ -112,12 +125,20 @@ public class GetDataExplicitTest extends BaseTest {
     @Test
     public void correctBehaviourTestCompress() throws Exception {
         try (InputStream stream = testingClient.getData(sessionId, new DataSelection().addDatafiles(datafileIds),
-                Flag.COMPRESS, 0, 200)) {
+                Flag.COMPRESS, 0, 200, r -> {
+                    assertThat(r.getFirstHeader("Content-Length"), is(nullValue()));
+                    assertThat(r.getFirstHeader("Transfer-Encoding").getValue(),
+                            is(equalToIgnoringCase("chunked")));
+                })) {
             checkZipStream(stream, datafileIds, 36L, 0);
         }
 
         try (InputStream stream = testingClient.getData(sessionId, new DataSelection().addDatafile(datafileIds.get(0)),
-                Flag.COMPRESS, 0, 200)) {
+                Flag.COMPRESS, 0, 200, r -> {
+                    assertThat(r.getFirstHeader("Content-Length"), is(nullValue()));
+                    assertThat(r.getFirstHeader("Transfer-Encoding").getValue(),
+                            is(equalToIgnoringCase("chunked")));
+                })) {
             checkStream(stream, datafileIds.get(0));
         }
     }
@@ -125,12 +146,20 @@ public class GetDataExplicitTest extends BaseTest {
     @Test
     public void correctBehaviourTestZip() throws Exception {
         try (InputStream stream = testingClient.getData(sessionId, new DataSelection().addDatafiles(datafileIds),
-                Flag.ZIP, 0, 200)) {
+                Flag.ZIP, 0, 200, r -> {
+                    assertThat(r.getFirstHeader("Content-Length"), is(nullValue()));
+                    assertThat(r.getFirstHeader("Transfer-Encoding").getValue(),
+                            is(equalToIgnoringCase("chunked")));
+                })) {
             checkZipStream(stream, datafileIds, 57L, 0);
         }
 
         try (InputStream stream = testingClient.getData(sessionId, new DataSelection().addDatafile(datafileIds.get(0)),
-                Flag.ZIP, 0, 200)) {
+                Flag.ZIP, 0, 200, r -> {
+                    assertThat(r.getFirstHeader("Content-Length"), is(nullValue()));
+                    assertThat(r.getFirstHeader("Transfer-Encoding").getValue(),
+                            is(equalToIgnoringCase("chunked")));
+                })) {
             checkZipStream(stream, datafileIds.subList(0, 1), 57L, 0);
         }
     }
@@ -138,12 +167,20 @@ public class GetDataExplicitTest extends BaseTest {
     @Test
     public void correctBehaviourTestZipAndCompress() throws Exception {
         try (InputStream stream = testingClient.getData(sessionId, new DataSelection().addDatafiles(datafileIds),
-                Flag.ZIP_AND_COMPRESS, 0, 200)) {
+                Flag.ZIP_AND_COMPRESS, 0, 200, r -> {
+                    assertThat(r.getFirstHeader("Content-Length"), is(nullValue()));
+                    assertThat(r.getFirstHeader("Transfer-Encoding").getValue(),
+                            is(equalToIgnoringCase("chunked")));
+                })) {
             checkZipStream(stream, datafileIds, 36L, 0);
         }
 
         try (InputStream stream = testingClient.getData(sessionId, new DataSelection().addDatafile(datafileIds.get(0)),
-                Flag.ZIP_AND_COMPRESS, 0, 200)) {
+                Flag.ZIP_AND_COMPRESS, 0, 200, r -> {
+                    assertThat(r.getFirstHeader("Content-Length"), is(nullValue()));
+                    assertThat(r.getFirstHeader("Transfer-Encoding").getValue(),
+                            is(equalToIgnoringCase("chunked")));
+                })) {
             checkZipStream(stream, datafileIds.subList(0, 1), 36L, 0);
         }
     }


### PR DESCRIPTION
Motivation:

The 'Content-Length' response header is expected by many clients.  While it is not possible to specify the content length for on-the-fly compression, it is possible when sending an individual file.

Modification:

Update DataSelection to optionally return the content length.

Update the 'getData' Response to include the `Content-Length` header when the request targets a single file that is not placed in a zip archive.  If the content is dynamically generated (e.g., a zip file) then no `Content-Length` header is provided.

Result:

IDS now includes the `Content-Length` response header when this is possible