### PR TITLE
added response conformity check to TestingClient

### DIFF
--- a/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
+++ b/src/test/java/org/icatproject/ids/integration/util/client/TestingClient.java
@@ -252,6 +252,7 @@ public class TestingClient {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
             HttpGet httpGet = new HttpGet(uri);
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+                checkResponseConformity(response);
                 return new URL(getString(response, sc));
             } catch (IOException | InsufficientStorageException | DataNotOnlineException | BadRequestException
                      | InsufficientPrivilegesException | NotFoundException e) {
@@ -291,6 +292,7 @@ public class TestingClient {
             httpclient = HttpClients.createDefault();
             response = httpclient.execute(httpGet);
             checkStatus(response, sc);
+            checkResponseConformity(response);
             closeNeeded = false;
             return new HttpInputStream(httpclient, response);
         } catch (IOException | InsufficientStorageException e) {
@@ -332,6 +334,7 @@ public class TestingClient {
             httpclient = HttpClients.createDefault();
             response = httpclient.execute(httpGet);
             checkStatus(response, sc);
+            checkResponseConformity(response);
             closeNeeded = false;
             return new HttpInputStream(httpclient, response);
         } catch (IOException | InsufficientStorageException e) {
@@ -367,6 +370,7 @@ public class TestingClient {
             HttpPost httpPost = new HttpPost(uri);
             httpPost.setEntity(new UrlEncodedFormEntity(formparams));
             try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
+                checkResponseConformity(response);
                 return Paths.get(getString(response, sc));
             } catch (InsufficientStorageException e) {
                 throw new InternalException(e.getClass() + " " + e.getMessage());
@@ -387,6 +391,7 @@ public class TestingClient {
             HttpGet httpGet = new HttpGet(uri);
 
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+                checkResponseConformity(response);
                 String result = getString(response, sc);
                 try (JsonReader jsonReader = Json.createReader(new StringReader(result))) {
                     ServiceStatus serviceStatus = new ServiceStatus();
@@ -433,6 +438,7 @@ public class TestingClient {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
             HttpGet httpGet = new HttpGet(uri);
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+                checkResponseConformity(response);
                 return Long.parseLong(getString(response, sc));
             } catch (IOException | InsufficientStorageException | DataNotOnlineException e) {
                 throw new InternalException(e.getClass() + " " + e.getMessage());
@@ -477,6 +483,7 @@ public class TestingClient {
             HttpGet httpGet = new HttpGet(uri);
 
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+                checkResponseConformity(response);
                 return Status.valueOf(getString(response, sc));
             } catch (InsufficientStorageException | DataNotOnlineException e) {
                 throw new InternalException(e.getClass() + " " + e.getMessage());
@@ -542,6 +549,7 @@ public class TestingClient {
             HttpGet httpGet = new HttpGet(uri);
 
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+                checkResponseConformity(response);
                 return Boolean.parseBoolean(getString(response, sc));
             } catch (InsufficientStorageException | DataNotOnlineException | InsufficientPrivilegesException e) {
                 throw new InternalException(e.getClass() + " " + e.getMessage());
@@ -556,6 +564,7 @@ public class TestingClient {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
             HttpGet httpGet = new HttpGet(uri);
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+                checkResponseConformity(response);
                 return Boolean.parseBoolean(getString(response, sc));
             } catch (IOException | InsufficientStorageException | DataNotOnlineException | BadRequestException
                      | InsufficientPrivilegesException | NotFoundException e) {
@@ -571,6 +580,7 @@ public class TestingClient {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
             HttpGet httpGet = new HttpGet(uri);
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+                checkResponseConformity(response);
                 return Boolean.parseBoolean(getString(response, sc));
             } catch (IOException | InsufficientStorageException | DataNotOnlineException | BadRequestException
                      | InsufficientPrivilegesException | NotFoundException e) {
@@ -587,6 +597,7 @@ public class TestingClient {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
             HttpGet httpGet = new HttpGet(uri);
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+                checkResponseConformity(response);
                 String result = getString(response, sc);
                 if (!result.equals("IdsOK")) {
                     throw new NotFoundException("Server gave invalid response: " + result);
@@ -621,6 +632,7 @@ public class TestingClient {
             HttpPost httpPost = new HttpPost(uri);
             httpPost.setEntity(entity);
             try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
+                checkResponseConformity(response);
                 return getString(response, sc);
             } catch (InsufficientStorageException | DataNotOnlineException e) {
                 throw new InternalException(e.getClass() + " " + e.getMessage());
@@ -672,6 +684,7 @@ public class TestingClient {
 
         try (CloseableHttpResponse response = httpclient.execute(httpPut)) {
             String result = getString(response, sc);
+            checkResponseConformity(response);
             try (JsonReader jsonReader = Json.createReader(new StringReader(result))) {
                 JsonObject rootNode = jsonReader.readObject();
                 if (rootNode.getJsonNumber("checksum").longValueExact() != crc.getValue()) {
@@ -730,6 +743,7 @@ public class TestingClient {
         httpPost.setEntity(entity);
 
         try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
+            checkResponseConformity(response);
             String result = getString(response, sc);
             String prefix = "<html><script type=\"text/javascript\">window.name='";
             String suffix = "';</script></html>";
@@ -786,6 +800,7 @@ public class TestingClient {
 
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
                 String result = getString(response, sc);
+                checkResponseConformity(response);
                 try (JsonReader jsonReader = Json.createReader(new StringReader(result))) {
 
                     JsonObject rootNode = jsonReader.readObject();
@@ -822,6 +837,7 @@ public class TestingClient {
             HttpGet httpGet = new HttpGet(uri);
 
             try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+                checkResponseConformity(response);
                 String result = getString(response, sc);
                 try (JsonReader jsonReader = Json.createReader(new StringReader(result))) {
 
@@ -908,6 +924,23 @@ public class TestingClient {
             }
         } catch (IOException e) {
             throw new InternalException(e.getClass() + " " + e.getMessage());
+        }
+    }
+
+    private void checkResponseConformity(HttpResponse response) throws InternalException {
+        
+        StatusLine status = response.getStatusLine();
+        var statusCode = status.getStatusCode();
+        if(statusCode == 200 && response.getEntity() != null) {
+            //we have a status of 200 and a payload. Check for header conformity
+            Boolean chunked = response.getFirstHeader("Transfer-Encoding") != null ? response.getFirstHeader("Transfer-Encoding").getValue().contains("chunked")
+                                                                                        : false;
+            
+            if ( (response.getFirstHeader("Content-Length") == null && !chunked)
+                || (response.getFirstHeader("Content-Length") != null && chunked ) ) {
+
+                throw new InternalException("Responses with payload should either contain the Content-Length header or the 'Transfer-Encoding: chunked' header. It needs exactly one of them.");
+            }
         }
     }
 


### PR DESCRIPTION
Related to #151 in this branch a conformity check for HTTP responses in the testing client was added.
It addresses the point that either the Content-Length header or the "Transfer-Encoding: chunked" header should be set in responses with a payload. If i understood right, exactly one of both headers has to be present at such responses. 