### PR TITLE
Add framework to allow test-specific assertions on HTTP response.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/icatproject/ids/integration/BaseTest.java
+++ b/src/test/java/org/icatproject/ids/integration/BaseTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.UUID;
 import java.util.zip.CRC32;
@@ -367,6 +369,15 @@ public class BaseTest {
             }
         }
         assertTrue(found);
+    }
+
+    protected long fileLength(long id) {
+        return ids.entrySet().stream()
+                .filter(e -> id == e.getValue())
+                .map(Map.Entry::getKey)
+                .map(fsizes::get)
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException("No file with id " + id));
     }
 
     protected void writeToFile(Datafile df, String content, String key)

--- a/src/test/java/org/icatproject/ids/integration/util/HeaderMatcher.java
+++ b/src/test/java/org/icatproject/ids/integration/util/HeaderMatcher.java
@@ -1,0 +1,92 @@
+package org.icatproject.ids.integration.util;
+
+import static java.util.Objects.requireNonNull;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+
+/**
+ * A custom header that matches HTTP headers in some HttpResponse object.  It
+ * supports two kind of matches: that the header is missing or that the header
+ * is present and the value matches some other Matcher.
+ */
+public class HeaderMatcher extends BaseMatcher<HttpResponse> {
+
+    private final String headerName;
+    private final Matcher<String> matcher;
+
+    public HeaderMatcher(String headerName, Matcher<String> valueMatcher) {
+        this.headerName = requireNonNull(headerName);
+        this.matcher = valueMatcher;
+    }
+
+    private boolean isHeaderExpected() {
+        return matcher != null;
+    }
+
+    @Override
+    public boolean matches(Object item) {
+        HttpResponse response = (HttpResponse) item; // It is a bug if item is not an HttpResponse.
+
+        Header header = response.getFirstHeader(headerName);
+
+        if (!isHeaderExpected()) {
+            return header == null;
+        }
+
+        if (header == null) {
+            return false;
+        }
+
+        String headerValue = header.getValue();
+
+        return matcher.matches(headerValue);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        if (isHeaderExpected()) {
+            description.appendText("a '")
+                    .appendText(headerName)
+                    .appendText("' header that ")
+                    .appendDescriptionOf(matcher);
+        } else {
+            description.appendText("no '").appendText(headerName).appendText("' header");
+        }
+    }
+
+    /**
+     * Match an HttpResponse that does not contain the named header.
+     * @param header The name of the HTTP response header.
+     * @return a Matcher that verifies expected response.
+     */
+    public static Matcher<HttpResponse> hasNoHeader(String header) {
+        return new HeaderMatcher(header, null);
+    }
+
+    /**
+     * Match an HttpResponse that contains the named header with a value that
+     * matches the supplied matcher.
+     * @param header The name of the HTTP response header.
+     * @param matcher The matcher for the header value.
+     * @return a Matcher that verifies expected response.
+     */
+    public static Matcher hasHeaderMatching(String header, Matcher<String> matcher) {
+        return new HeaderMatcher(header, matcher);
+    }
+
+    /**
+     * Match an HttpResponse that contains the named header with the specific
+     * value (ignoring case).
+     * @param header The name of the HTTP response header.
+     * @param value The expected value.
+     * @return a Matcher that verifies expected response.
+     */
+    public static Matcher hasHeader(String header, Object value) {
+        Matcher<String> m = equalToIgnoringCase(String.valueOf(value));
+        return hasHeaderMatching(header, m);
+    }
+}

--- a/src/test/java/org/icatproject/ids/integration/util/LongValue.java
+++ b/src/test/java/org/icatproject/ids/integration/util/LongValue.java
@@ -1,0 +1,33 @@
+package org.icatproject.ids.integration.util;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * A Matcher that checks whether a String argument is a Long value.  The code is
+ * heavily based on an answer from Ezequiel to
+ * <a href="https://stackoverflow.com/questions/58099695/is-there-a-way-in-hamcrest-to-test-for-a-value-to-be-a-number">
+ * a stack overview question</a>.
+ */
+public class LongValue extends TypeSafeMatcher<String> {
+
+    @Override
+    protected boolean matchesSafely(String s) {
+        try {
+            Long.valueOf(s);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("is long");
+    }
+
+    public static Matcher<String> longValue() {
+        return new LongValue();
+    }
+}


### PR DESCRIPTION
Motivation:

Individual tests may have certain expectations on how IDS responds to
HTTP requests.

Some interactions supported by `TestingClient` exercise IDS requests
that return content; for example, `getData`.  For these interactions,
`TestingClient` returns the content from IDS and not the HTTP response.
This makes it impossible for a test to assert that, for these
interactions, the HTTP response from IDS matches the test's
expectations.

Modification:

Update `TestingClient` to allow the test to include one or more
assertions on the HTTP response.  The support following the builder
pattern.

The assertions are provided by the test as Consumer objects that accept
an HttpResponse object, with lambdas providing an easy to build such
objects.  Some static methods are included that provide common
assertions, to keep code readable and DRY.

The Apache client is customised to include a response interceptor,
through which the assertions are made.

The existing code that checks the combined `Content-Length` (if present)
and `Transfer-Encoding` headers (if present) is valid is refactored to
take advantage of this framework.  This check now applies uniformly to
all HTTP responses from IDS.

Some other, existing tests are updated to take advantage of the new
framework.

Further refactoring is possible; for example, to make the check on the
response's status code more explicit.  Such a refactoring would reduce
the complexity of the `TestingClient` interaction methods by reducing
the parameter count.

Result:

It is now possible to write tests that make test-specific assertions on
the HTTP response from IDS for interactions where IDS returns content.