### PR TITLE
Include Content-Length response header

### DIFF
--- a/src/main/java/org/icatproject/ids/DataSelection.java
+++ b/src/main/java/org/icatproject/ids/DataSelection.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
 
 import jakarta.json.Json;
@@ -53,6 +54,7 @@ public class DataSelection {
     private Set<Long> emptyDatasets;
     private boolean dsWanted;
     private boolean dfWanted;
+    private long length;
 
 
     public enum Returns {
@@ -135,6 +137,7 @@ public class DataSelection {
                     dsInfos.put(dsid, new DsInfoImpl(ds));
                     if (dfWanted) {
                         Datafile df = (Datafile) icat.get(userSessionId, "Datafile", dfid);
+                        length += df.getFileSize();
                         String location = IdsBean.getLocation(dfid, df.getLocation());
                         dfInfos.add(
                                 new DfInfoImpl(dfid, df.getName(), location, df.getCreateId(), df.getModId(), dsid));
@@ -315,4 +318,10 @@ public class DataSelection {
         return emptyDatasets;
     }
 
+    public OptionalLong getFileLength() {
+        if (!dfWanted || mustZip()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(length);
+    }
 }

--- a/src/main/java/org/icatproject/ids/IdsBean.java
+++ b/src/main/java/org/icatproject/ids/IdsBean.java
@@ -20,6 +20,7 @@ import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -50,6 +51,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonGenerator;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
@@ -859,6 +861,7 @@ public class IdsBean {
         // Do it
         Map<Long, DsInfo> dsInfos = dataSelection.getDsInfo();
         Set<DfInfoImpl> dfInfos = dataSelection.getDfInfo();
+        var length = zip ? OptionalLong.empty() : dataSelection.getFileLength();
 
         Lock lock = null;
         try {
@@ -909,11 +912,14 @@ public class IdsBean {
                 }
             }
 
-            return Response.status(offset == 0 ? HttpURLConnection.HTTP_OK : HttpURLConnection.HTTP_PARTIAL)
+            var response = Response.status(offset == 0 ? HttpURLConnection.HTTP_OK : HttpURLConnection.HTTP_PARTIAL)
                     .entity(new SO(dataSelection.getDsInfo(), dataSelection.getDfInfo(), offset, finalZip, compress, lock,
                             transferId, ip, start))
-                    .header("Content-Disposition", "attachment; filename=\"" + name + "\"").header("Accept-Ranges", "bytes")
-                    .build();
+                    .header("Content-Disposition", "attachment; filename=\"" + name + "\"").header("Accept-Ranges", "bytes");
+            length.stream()
+                    .map(l -> Math.max(0L, l - offset))
+                    .forEach(l -> response.header(CONTENT_LENGTH, l));
+            return response.build();
         } catch (AlreadyLockedException e) {
             logger.debug("Could not acquire lock, getData failed");
             throw new DataNotOnlineException("Data is busy");


### PR DESCRIPTION
Motivation:

The 'Content-Length' response header is expected by many clients.  While it is not possible to specify the content length for on-the-fly compression, it is possible when sending an individual file.

Modification:

Update DataSelection to optionally return the content length.

Update the 'getData' Response to include the `Content-Length` header when the request targets a single file that is not placed in a zip archive.  If the content is dynamically generated (e.g., a zip file) then no `Content-Length` header is provided.

Result:

IDS now includes the `Content-Length` response header when this is possible