### PR TITLE
Fix duplicate calls of mainStorage.lock() in LockManager

### DIFF
--- a/src/main/java/org/icatproject/ids/LockManager.java
+++ b/src/main/java/org/icatproject/ids/LockManager.java
@@ -41,7 +41,7 @@ public class LockManager {
         final AutoCloseable storageLock;
         int count;
 
-        LockEntry(Long id, LockType type,  AutoCloseable storageLock) {
+        LockEntry(Long id, LockType type, AutoCloseable storageLock) {
             this.id = id;
             this.type = type;
             this.storageLock = storageLock;

--- a/src/main/java/org/icatproject/ids/LockManager.java
+++ b/src/main/java/org/icatproject/ids/LockManager.java
@@ -38,11 +38,13 @@ public class LockManager {
     private class LockEntry {
         final Long id;
         final LockType type;
+        final AutoCloseable storageLock;
         int count;
 
-        LockEntry(Long id, LockType type) {
+        LockEntry(Long id, LockType type,  AutoCloseable storageLock) {
             this.id = id;
             this.type = type;
+            this.storageLock = storageLock;
             this.count = 0;
             lockMap.put(id, this);
         }
@@ -56,6 +58,13 @@ public class LockManager {
             count -= 1;
             if (count == 0) {
                 lockMap.remove(id);
+                if (storageLock != null) {
+                    try {
+                        storageLock.close();
+                    } catch (Exception e) {
+                        logger.error("Error while closing lock on {} in the storage plugin: {}.", id, e.getMessage());
+                    }
+                }
             }
         }
     }
@@ -74,12 +83,10 @@ public class LockManager {
     private class SingleLock extends Lock {
         private final Long id;
         private boolean isValid;
-        private AutoCloseable storageLock;
 
-        SingleLock(Long id, AutoCloseable storageLock) {
+        SingleLock(Long id) {
             this.id = id;
             this.isValid = true;
-            this.storageLock = storageLock;
         }
 
         public void release() {
@@ -87,13 +94,6 @@ public class LockManager {
                 if (isValid) {
                     lockMap.get(id).dec();
                     isValid = false;
-                    if (storageLock != null) {
-                        try {
-                            storageLock.close();
-                        } catch (Exception e) {
-                            logger.error("Error while closing lock on {} in the storage plugin: {}.", id, e.getMessage());
-                        }
-                    }
                     logger.debug("Released a lock on {}.", id);
                 }
             }
@@ -136,22 +136,17 @@ public class LockManager {
         synchronized (lockMap) {
             LockEntry le = lockMap.get(id);
             if (le == null) {
-                le = new LockEntry(id, type);
+                AutoCloseable storageLock;
+                storageLock = mainStorage.lock(ds, type == LockType.SHARED);
+                le = new LockEntry(id, type, storageLock);
             } else {
                 if (type == LockType.EXCLUSIVE || le.type == LockType.EXCLUSIVE) {
                     throw new AlreadyLockedException();
                 }
             }
             le.inc();
-            AutoCloseable storageLock;
-            try {
-                storageLock = mainStorage.lock(ds, type == LockType.SHARED);
-            } catch (AlreadyLockedException | IOException e) {
-                le.dec();
-                throw e;
-            }
             logger.debug("Acquired a {} lock on {}.", type, id);
-            return new SingleLock(id, storageLock);
+            return new SingleLock(id);
         }
     }
 

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -7,7 +7,9 @@
 <h1>IDS Server Release Notes</h1>
 
 <h2>2.1.1 (not yet released)</h2>
+<p>Bug fix release</p>
 <ul>
+    <li>#164, #166: Fix duplicate calls of mainStorage.lock() in LockManager.</li>
     <li>#140, #158: Fix miredot build.</li>
 </ul>
 


### PR DESCRIPTION
- store the storage lock in class LockEntry rather than in class SingleLock,
- as a consequence: obtain only one storage lock when mutliple shared locks are requested on the same dataset,
- release the storage lock when the lock count drops to zero, e.g. when the last lock on the dataset is closed.

This fixes #164.